### PR TITLE
Refactor - 모든 화면 및 원서 화면 레이아웃, 퀄리티 증가

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "codium.codeCompletion.enable": true
+}

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,33 @@
+import js from "@eslint/js";
+import globals from "globals";
+import reactHooks from "eslint-plugin-react-hooks";
+import reactRefresh from "eslint-plugin-react-refresh";
+
+export default [
+  { ignores: ["dist"] },
+  {
+    files: ["**/*.{js,jsx}"],
+    languageOptions: {
+      ecmaVersion: 2020,
+      globals: globals.browser,
+      parserOptions: {
+        ecmaVersion: "latest",
+        ecmaFeatures: { jsx: true },
+        sourceType: "module",
+      },
+    },
+    plugins: {
+      "react-hooks": reactHooks,
+      "react-refresh": reactRefresh,
+    },
+    rules: {
+      ...js.configs.recommended.rules,
+      ...reactHooks.configs.recommended.rules,
+      "no-unused-vars": ["error", { varsIgnorePattern: "^[A-Z_]" }],
+      "react-refresh/only-export-components": [
+        "warn",
+        { allowConstantExport: true },
+      ],
+    },
+  },
+];

--- a/src/components/Layout.js
+++ b/src/components/Layout.js
@@ -1,216 +1,76 @@
-// Layout.js - 스크롤 문제가 해결된 레이아웃 컴포넌트
+// Layout.js - 업데이트된 레이아웃 컴포넌트
 import { useState } from 'react';
-import { Link, useLocation, Outlet } from 'react-router-dom';
-import { 
-  Home, 
-  BookOpen, 
-  FolderOpen, 
-  Calendar, 
-  Book, 
-  Menu, 
-  ChevronsLeft,
-  BarChart3,
-  NotebookPen,
-  Sparkles,
-} from 'lucide-react';
-import FloatingCalender from './FloatingCalender';
-
-const studyNavItems = [
-  { id: 'content', label: '원서 본문', icon: BookOpen, path: 'content', color: 'emerald' },
-  { id: 'notes', label: '노트', icon: NotebookPen, path: 'notes', color: 'amber' },
-  { id: 'progress', label: '학습 현황', icon: BarChart3, path: 'progress', color: 'violet' },
-];
+import { useLocation, Outlet } from 'react-router-dom';
+import Sidebar from '../components/layout/Sidebar';
+import StudySidebar from '../components/layout/StudySidebar';
 
 const Layout = () => {
-  const [sidebarOpen, setSidebarOpen] = useState(true); // 일반 nav용
-  const [sidebarCollapsed, setSidebarCollapsed] = useState(false); // 학습 nav용
+  const [sidebarOpen, setSidebarOpen] = useState(false); // 일반 사이드바용 - 기본값 false로 변경
+  const [studySidebarCollapsed, setStudySidebarCollapsed] = useState(true); // 학습 사이드바용 - 기본값 true로 변경
   const [activeView, setActiveView] = useState('content'); // 학습 nav용
   const location = useLocation();
+
   // /textbook/:id/study(및 하위) 경로 감지
   const isStudyPage = /^\/textbook\/[^/]+\/study/.test(location.pathname);
+  
   // id 추출 (학습 nav 링크용)
-  let id = null;
+  let textbookId = null;
   if (isStudyPage) {
     const match = location.pathname.match(/^\/textbook\/(\w+)\/study/);
-    id = match ? match[1] : null;
+    textbookId = match ? match[1] : null;
   }
 
-  // 기존 메뉴
-  const mainMenuItems = [
-    {
-      id: 'dashboard',
-      title: '대시보드',
-      icon: Home,
-      path: '/dashboard',
-      exact: true,
-      color: 'blue',
-      gradient: 'from-blue-500 to-cyan-500'
-    },
-    {
-      id: 'study',
-      title: '학습 관리',
-      icon: BookOpen,
-      path: '/study',
-      subPaths: ['/study/:id'],
-      color: 'emerald',
-      gradient: 'from-emerald-500 to-teal-500'
-    },
-    {
-      id: 'project',
-      title: '프로젝트 관리',
-      icon: FolderOpen,
-      path: '/project',
-      color: 'violet',
-      gradient: 'from-violet-500 to-purple-500'
-    },
-    {
-      id: 'textbook',
-      title: '원서 관리',
-      icon: Book,
-      path: '/textbook',
-      color: 'blue',
-      gradient: 'from-orange-500 to-red-500'
-    },
-    {
-      id: 'calendar',
-      title: '학습 캘린더',
-      icon: Calendar,
-      path: '/calendar',
-      color: 'pink',
-      gradient: 'from-pink-500 to-rose-500'
-    },
-  ];
-
-  // 학습 nav 클릭 시 activeView 변경
-  const handleStudyNavClick = (item) => {
-    setActiveView(item.id);
+  // 사이드바 토글 핸들러
+  const handleSidebarToggle = () => {
+    if (isStudyPage) {
+      setStudySidebarCollapsed(!studySidebarCollapsed);
+    } else {
+      setSidebarOpen(!sidebarOpen);
+    }
   };
 
-  const getColorClasses = (color, isActive = false) => {
-    const colors = {
-      blue: isActive ? 'bg-blue-50 text-blue-700 border-blue-200' : 'hover:bg-blue-50 hover:text-blue-600',
-      emerald: isActive ? 'bg-emerald-50 text-emerald-700 border-emerald-200' : 'hover:bg-emerald-50 hover:text-emerald-600',
-      violet: isActive ? 'bg-violet-50 text-violet-700 border-violet-200' : 'hover:bg-violet-50 hover:text-violet-600',
-      orange: isActive ? 'bg-orange-50 text-orange-700 border-orange-200' : 'hover:bg-orange-50 hover:text-orange-600',
-      pink: isActive ? 'bg-pink-50 text-pink-700 border-pink-200' : 'hover:bg-pink-50 hover:text-pink-600',
-      amber: isActive ? 'bg-amber-50 text-amber-700 border-amber-200' : 'hover:bg-amber-50 hover:text-amber-600',
-    };
-    return colors[color] || colors.blue;
+  // 학습 뷰 변경 핸들러
+  const handleViewChange = (viewId) => {
+    setActiveView(viewId);
   };
+
+  // 학습 타이머 상태 관리
+  const [studyTimer, setStudyTimer] = useState(0);
 
   return (
     <div className="flex h-screen bg-gradient-to-br from-slate-50 via-white to-blue-50/30 overflow-hidden">
-      {/* 사이드바 */}
-      <div className={`bg-white/80 shadow-xl border-r border-slate-200/60 transition-all duration-500 flex flex-col flex-shrink-0
-        ${isStudyPage ? (sidebarCollapsed ? 'w-16' : 'w-72') : (sidebarOpen ? 'w-72' : 'w-16')}`}>
-        {/* 헤더 */}
-        <div className="p-4 border-b border-slate-100 flex-shrink-0 relative z-10">
-          <div className="flex items-center justify-between">
-            {((isStudyPage && !sidebarCollapsed) || (!isStudyPage && sidebarOpen)) && (
-              <div className="flex items-center gap-3">
-                <div className="w-8 h-8 rounded-xl bg-gradient-to-br from-blue-500 to-violet-600 flex items-center justify-center shadow-lg">
-                  {isStudyPage ? (
-                    <Sparkles size={18} className="text-white" />
-                  ) : (
-                    <div className="w-4 h-4 bg-white rounded-full"></div>
-                  )}
-                </div>
-                <div>
-                  <h1 className="text-xl font-bold bg-gradient-to-r from-slate-900 to-slate-600 bg-clip-text text-transparent">
-                    {isStudyPage ? 'Focus Mode' : 'Slacko'}
-                  </h1>
-                  {isStudyPage && (
-                    <p className="text-sm text-slate-500 -mt-0.5">집중 학습 환경</p>
-                  )}
-                </div>
-              </div>
-            )}
-            <button
-              onClick={() => isStudyPage ? setSidebarCollapsed(!sidebarCollapsed) : setSidebarOpen(!sidebarOpen)}
-              className="p-2.5 hover:bg-slate-100 rounded-xl transition-all duration-300 border border-slate-200 hover:border-slate-300 shadow-sm hover:shadow-md group"
-            >
-              {(isStudyPage ? sidebarCollapsed : !sidebarOpen) ? (
-                <Menu size={18} className="text-slate-600 group-hover:text-slate-800 transition-colors" />
-              ) : (
-                <ChevronsLeft size={18} className="text-slate-600 group-hover:text-slate-800 transition-colors" />
-              )}
-            </button>
-          </div>
-        </div>
-        {/* nav 영역 */}
-        <nav className="flex-1 p-2 space-y-2 overflow-y">
-          {isStudyPage && id ? (
-            <div className="space-y-2">
-              {studyNavItems.map((item) => {
-                const isActive = activeView === item.id;
-                return (
-                  <button
-                    key={item.id}
-                    onClick={() => handleStudyNavClick(item)}
-                    className={`group flex items-center gap-3 px-2 py-3 rounded-xl text-sm font-medium transition-all duration-300 w-full text-left relative
-                      ${getColorClasses(item.color, isActive)}
-                      ${isActive ? 'shadow-sm border transform scale-[1.02]' : 'text-slate-700 hover:transform hover:scale-[1.01]'}
-                    `}
-                  >
-                    <div className={`p-2 rounded-lg ${isActive ? `bg-${item.color}-100` : 'bg-slate-100 group-hover:bg-slate-200'} transition-colors`}>
-                      <item.icon size={16} />
-                    </div>
-                    {!sidebarCollapsed && (
-                      <span className="flex-1">{item.label}</span>
-                    )}
-                    {isActive && !sidebarCollapsed && (
-                      <div className={`w-2 h-2 rounded-full bg-${item.color}-500 animate-pulse`}></div>
-                    )}
-                  </button>
-                );
-              })}
-            </div>
-          ) : (
-            <div className="space-y-2">
-              {mainMenuItems.map((item) => {
-                const isActive = location.pathname.startsWith(item.path);
-            return (
-              <Link
-                key={item.id}
-                to={item.path}
-                    className={`group flex items-center gap-3 px-2 py-3 rounded-xl text-sm font-medium transition-all duration-300 relative overflow-hidden
-                      ${getColorClasses(item.color, isActive)}
-                      ${isActive ? 'shadow-md border transform scale-[1.02]' : 'text-slate-700 hover:transform hover:scale-[1.01]'}
-                    `}
-                  >
-                    {isActive && (
-                      <div className={`absolute inset-0 bg-gradient-to-r ${item.gradient} opacity-10`}></div>
-                    )}
-                    <div className={`relative p-2 rounded-lg ${isActive ? `bg-${item.color}-100` : 'bg-slate-100 group-hover:bg-slate-200'} transition-colors z-10`}>
-                      <item.icon size={16} />
-                    </div>
-                    {sidebarOpen && (
-                      <>
-                        <span className="flex-1 relative z-10">{item.title}</span>
-                        {isActive && (
-                          <div className={`w-2 h-2 rounded-full bg-gradient-to-r ${item.gradient} animate-pulse z-10`}></div>
-                    )}
-                  </>
-                )}
-              </Link>
-            );
-          })}
-            </div>
-          )}
-        </nav>
-        {/* 캘린더 등 부가 영역 */}
-        <div className="px-2 pb-4">
-          {!isStudyPage && <FloatingCalender />}
-          </div>
-      </div>
+      {/* 사이드바 - 조건부 렌더링 */}
+      {isStudyPage ? (
+        <StudySidebar
+          isCollapsed={studySidebarCollapsed}
+          onToggle={handleSidebarToggle}
+          activeView={activeView}
+          onViewChange={handleViewChange}
+          textbookId={textbookId}
+          studyTimer={studyTimer}
+          setStudyTimer={setStudyTimer}
+        />
+      ) : (
+        <Sidebar
+          isOpen={sidebarOpen}
+          onToggle={handleSidebarToggle}
+        />
+      )}
+
       {/* 메인 컨텐츠 */}
       <div className="flex-1 flex flex-col min-h-0">
         <div className="flex-1 min-h-0 overflow-x-hidden overflow-y-auto">
-          <Outlet context={{ 
-            activeView, 
-            sidebarOpen: isStudyPage ? !sidebarCollapsed : sidebarOpen,
-            sidebarCollapsed: isStudyPage ? sidebarCollapsed : !sidebarOpen
-          }} key={location.pathname} />
+          <Outlet 
+            context={{ 
+              activeView, 
+              sidebarOpen: isStudyPage ? !studySidebarCollapsed : sidebarOpen,
+              sidebarCollapsed: isStudyPage ? studySidebarCollapsed : !sidebarOpen,
+              isStudyMode: isStudyPage,
+              studyTimer,
+              setStudyTimer
+            }} 
+            key={location.pathname} 
+          />
         </div>
       </div>
     </div>

--- a/src/components/layout/Sidebar.js
+++ b/src/components/layout/Sidebar.js
@@ -1,0 +1,225 @@
+// Sidebar.js - 메인 사이드바 컴포넌트
+import { useState } from 'react';
+import { Link, useLocation } from 'react-router-dom';
+import { 
+  Home, 
+  BookOpen, 
+  FolderOpen, 
+  Calendar, 
+  Book, 
+  Menu, 
+  ChevronsLeft,
+  Settings,
+  User,
+  Bell,
+  Search,
+  Plus,
+  MoreHorizontal
+} from 'lucide-react';
+
+const Sidebar = ({ isOpen, onToggle }) => {
+  const location = useLocation();
+  const [searchFocused, setSearchFocused] = useState(false);
+
+  const mainMenuItems = [
+    {
+      id: 'dashboard',
+      title: '대시보드',
+      icon: Home,
+      path: '/dashboard',
+      exact: true,
+      color: 'blue',
+      gradient: 'from-blue-500 to-cyan-500'
+    },
+    {
+      id: 'study',
+      title: '학습 관리',
+      icon: BookOpen,
+      path: '/study',
+      subPaths: ['/study/:id'],
+      color: 'emerald',
+      gradient: 'from-emerald-500 to-teal-500'
+    },
+    {
+      id: 'project',
+      title: '프로젝트 관리',
+      icon: FolderOpen,
+      path: '/project',
+      color: 'violet',
+      gradient: 'from-violet-500 to-purple-500'
+    },
+    {
+      id: 'textbook',
+      title: '원서 관리',
+      icon: Book,
+      path: '/textbook',
+      color: 'orange',
+      gradient: 'from-orange-500 to-red-500'
+    },
+    {
+      id: 'calendar',
+      title: '학습 캘린더',
+      icon: Calendar,
+      path: '/calendar',
+      color: 'pink',
+      gradient: 'from-pink-500 to-rose-500'
+    },
+  ];
+
+  const getColorClasses = (color, isActive = false) => {
+    if (!isOpen && !isActive) return 'text-slate-400 hover:text-slate-300 hover:bg-slate-800/50';
+    
+    const colors = {
+      blue: isActive ? 'bg-blue-500/20 text-blue-300 border-l-2 border-blue-400' : 'text-slate-300 hover:text-blue-300 hover:bg-blue-500/10',
+      emerald: isActive ? 'bg-emerald-500/20 text-emerald-300 border-l-2 border-emerald-400' : 'text-slate-300 hover:text-emerald-300 hover:bg-emerald-500/10',
+      violet: isActive ? 'bg-violet-500/20 text-violet-300 border-l-2 border-violet-400' : 'text-slate-300 hover:text-violet-300 hover:bg-violet-500/10',
+      orange: isActive ? 'bg-orange-500/20 text-orange-300 border-l-2 border-orange-400' : 'text-slate-300 hover:text-orange-300 hover:bg-orange-500/10',
+      pink: isActive ? 'bg-pink-500/20 text-pink-300 border-l-2 border-pink-400' : 'text-slate-300 hover:text-pink-300 hover:bg-pink-500/10',
+    };
+    return colors[color] || colors.blue;
+  };
+
+  const getIconBgClass = (color, isActive) => {
+    if (!isOpen) return 'bg-slate-700/50';
+    const classes = {
+      blue: isActive ? 'bg-blue-100' : 'bg-slate-700/50 group-hover:bg-slate-600/50',
+      emerald: isActive ? 'bg-emerald-100' : 'bg-slate-700/50 group-hover:bg-slate-600/50',
+      violet: isActive ? 'bg-violet-100' : 'bg-slate-700/50 group-hover:bg-slate-600/50',
+      orange: isActive ? 'bg-orange-100' : 'bg-slate-700/50 group-hover:bg-slate-600/50',
+      pink: isActive ? 'bg-pink-100' : 'bg-slate-700/50 group-hover:bg-slate-600/50',
+    };
+    return classes[color] || classes.blue;
+  };
+
+  const getDotClass = (color) => {
+    const classes = {
+      blue: 'bg-blue-400',
+      emerald: 'bg-emerald-400',
+      violet: 'bg-violet-400',
+      orange: 'bg-orange-400',
+      pink: 'bg-pink-400',
+    };
+    return classes[color] || classes.blue;
+  };
+
+  return (
+    <div className={`bg-slate-900/95 backdrop-blur-sm border-r border-slate-800/50 transition-all duration-300 flex flex-col flex-shrink-0 relative
+      ${isOpen ? 'w-64' : 'w-16'}`}>
+      
+      {/* Header */}
+      <div className="p-4 border-b border-slate-800/50 flex-shrink-0">
+        <div className="flex items-center justify-between">
+          {isOpen ? (
+            <div className="flex items-center gap-3">
+              <div className="w-8 h-8 rounded-lg bg-gradient-to-br from-blue-500 to-violet-600 flex items-center justify-center shadow-lg">
+                <div className="w-4 h-4 bg-white rounded-sm"></div>
+              </div>
+              <div>
+                <h1 className="text-lg font-bold text-white">Slacko</h1>
+                <p className="text-xs text-slate-400 -mt-0.5">학습 관리 플랫폼</p>
+              </div>
+            </div>
+          ) : (
+            <div className="w-8 h-8 rounded-lg bg-gradient-to-br from-blue-500 to-violet-600 flex items-center justify-center shadow-lg mx-auto">
+              <div className="w-4 h-4 bg-white rounded-sm"></div>
+            </div>
+          )}
+          
+          {isOpen && (
+            <button
+              onClick={onToggle}
+              className="p-2 text-slate-400 hover:text-slate-300 hover:bg-slate-800/50 rounded-lg transition-all duration-200"
+            >
+              <ChevronsLeft size={18} />
+            </button>
+          )}
+        </div>
+      </div>
+
+      {/* Search Bar */}
+      {isOpen && (
+        <div className="p-4 border-b border-slate-800/30">
+          <div className={`relative transition-all duration-200 ${searchFocused ? 'scale-105' : ''}`}>
+            <Search size={16} className="absolute left-3 top-1/2 transform -translate-y-1/2 text-slate-400" />
+            <input
+              type="text"
+              placeholder="검색..."
+              onFocus={() => setSearchFocused(true)}
+              onBlur={() => setSearchFocused(false)}
+              className="w-full pl-10 pr-4 py-2.5 bg-slate-800/50 border border-slate-700/50 rounded-lg text-sm text-white placeholder-slate-400 
+                focus:outline-none focus:ring-2 focus:ring-blue-500/50 focus:border-blue-500/50 transition-all duration-200"
+            />
+            {searchFocused && (
+              <div className="absolute right-3 top-1/2 transform -translate-y-1/2">
+                <kbd className="px-2 py-1 text-xs text-slate-400 bg-slate-700 rounded">⌘K</kbd>
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+
+      {/* Navigation */}
+      <nav className="flex-1 p-1.5 overflow-y-auto">
+        <div className="space-y-1">
+          {mainMenuItems.map((item) => {
+            const isActive = location.pathname.startsWith(item.path);
+            return (
+              <Link
+                key={item.id}
+                to={item.path}
+                className={`group flex items-center gap-3 px-3 py-2.5 rounded-lg text-sm font-medium transition-all duration-200 relative
+                  ${getColorClasses(item.color, isActive)}
+                  ${isActive ? 'transform scale-[1.02]' : 'hover:transform hover:scale-[1.01]'}
+                `}
+              >
+                <div className={`flex-shrink-0 ${isOpen ? '' : 'mx-auto'}`}>
+                  <div className={`p-2 rounded-lg transition-colors ${getIconBgClass(item.color, isActive)}`}>
+                    <item.icon size={18} />
+                  </div>
+                </div>
+                {isOpen && (
+                  <>
+                    <span className="flex-1 truncate">{item.title}</span>
+                    {isActive && (
+                      <div className={`w-1.5 h-1.5 rounded-full animate-pulse ${getDotClass(item.color)}`}></div>
+                    )}
+                  </>
+                )}
+                {!isOpen && isActive && (
+                  <div className="absolute right-0 top-1/2 transform -translate-y-1/2 w-1 h-6 bg-blue-400 rounded-l-full"></div>
+                )}
+              </Link>
+            );
+          })}
+        </div>
+      </nav>
+
+      {/* User Section */}
+      <div className="p-4 border-t border-slate-800/50 flex-shrink-0">
+        {isOpen ? (
+          <div className="flex items-center gap-3">
+            <div className="w-8 h-8 rounded-lg bg-gradient-to-br from-emerald-500 to-teal-600 flex items-center justify-center">
+              <User size={16} className="text-white" />
+            </div>
+            <div className="flex-1 min-w-0">
+              <p className="text-sm font-medium text-white truncate">사용자</p>
+              <p className="text-xs text-slate-400">온라인</p>
+            </div>
+            <button className="p-2 text-slate-400 hover:text-slate-300 hover:bg-slate-800/50 rounded-lg transition-all duration-200">
+              <Settings size={16} />
+            </button>
+          </div>
+        ) : (
+          <button
+            onClick={onToggle}
+            className="w-full p-2 text-slate-400 hover:text-slate-300 hover:bg-slate-800/50 rounded-lg transition-all duration-200"
+          >
+            <Menu size={18} />
+          </button>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default Sidebar;

--- a/src/components/layout/Sidebar.js
+++ b/src/components/layout/Sidebar.js
@@ -11,10 +11,7 @@ import {
   ChevronsLeft,
   Settings,
   User,
-  Bell,
   Search,
-  Plus,
-  MoreHorizontal
 } from 'lucide-react';
 
 const Sidebar = ({ isOpen, onToggle }) => {

--- a/src/components/layout/StudySidebar.js
+++ b/src/components/layout/StudySidebar.js
@@ -1,0 +1,364 @@
+// StudySidebar.js - 학습 모드 전용 사이드바
+import { useState, useEffect } from 'react';
+import {
+  BookOpen,
+  BarChart3,
+  NotebookPen,
+  Sparkles,
+  Menu,
+  ChevronsLeft,
+  Timer,
+  Target,
+  Zap,
+  ArrowLeft,
+  Focus
+} from 'lucide-react';
+
+const StudySidebar = ({ 
+  isCollapsed, 
+  onToggle, 
+  activeView, 
+  onViewChange, 
+  textbookId, 
+  studyTimer, 
+  setStudyTimer,
+  // isStudying,
+  // setIsStudying 
+}) => {
+  // 목표 시간 (초 단위)
+  const [targetTime] = useState(2 * 60 * 60); // 2시간
+
+  const studyNavItems = [
+    { 
+      id: 'content', 
+      label: '원서 본문', 
+      icon: BookOpen, 
+      path: 'content', 
+      color: 'emerald',
+      description: '교재 내용 학습'
+    },
+    { 
+      id: 'notes', 
+      label: '노트', 
+      icon: NotebookPen, 
+      path: 'notes', 
+      color: 'amber',
+      description: '학습 노트 작성'
+    },
+    { 
+      id: 'progress', 
+      label: '학습 현황', 
+      icon: BarChart3, 
+      path: 'progress', 
+      color: 'violet',
+      description: '진도 및 성과 확인'
+    },
+  ];
+
+  // 학습 상태 관리
+  const [isStudying, setIsStudying] = useState(true);
+
+  // 자동 학습 시간 측정 - 페이지 포커스 기반
+  useEffect(() => {
+    let interval;
+    let isPageVisible = true;
+    
+    const handleVisibilityChange = () => {
+      isPageVisible = !document.hidden;
+      setIsStudying(!document.hidden);
+    };
+    
+    const handleFocus = () => {
+      isPageVisible = true;
+      setIsStudying(true);
+    };
+    
+    const handleBlur = () => {
+      isPageVisible = false;
+      setIsStudying(false);
+    };
+
+    // 초기 상태 설정
+    setIsStudying(!document.hidden);
+
+    // 자동 시간 측정 - 페이지가 보이는 상태일 때만 측정
+    interval = setInterval(() => {
+      if (isPageVisible) {
+        setStudyTimer(prev => prev + 1);
+      }
+    }, 1000);
+
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+    window.addEventListener('focus', handleFocus);
+    window.addEventListener('blur', handleBlur);
+
+    return () => {
+      if (interval) clearInterval(interval);
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+      window.removeEventListener('focus', handleFocus);
+      window.removeEventListener('blur', handleBlur);
+    };
+  }, [setStudyTimer]);
+
+  const getColorClasses = (color, isActive = false) => {
+    if (isCollapsed && !isActive) return 'text-slate-400 hover:text-slate-300 hover:bg-slate-800/50';
+    
+    const colors = {
+      emerald: isActive 
+        ? 'bg-emerald-500/20 text-emerald-300 border-l-2 border-emerald-400 shadow-lg shadow-emerald-500/20' 
+        : 'text-slate-300 hover:text-emerald-300 hover:bg-emerald-500/10 hover:shadow-md hover:shadow-emerald-500/10',
+      amber: isActive 
+        ? 'bg-amber-500/20 text-amber-300 border-l-2 border-amber-400 shadow-lg shadow-amber-500/20' 
+        : 'text-slate-300 hover:text-amber-300 hover:bg-amber-500/10 hover:shadow-md hover:shadow-amber-500/10',
+      violet: isActive 
+        ? 'bg-violet-500/20 text-violet-300 border-l-2 border-violet-400 shadow-lg shadow-violet-500/20' 
+        : 'text-slate-300 hover:text-violet-300 hover:bg-violet-500/10 hover:shadow-md hover:shadow-violet-500/10',
+    };
+    return colors[color] || colors.emerald;
+  };
+
+  const getIconBgClass = (color, isActive) => {
+    const classes = {
+      emerald: isActive ? 'bg-emerald-400/20' : 'bg-slate-700/50 group-hover:bg-slate-600/50',
+      amber: isActive ? 'bg-amber-400/20' : 'bg-slate-700/50 group-hover:bg-slate-600/50',
+      violet: isActive ? 'bg-violet-400/20' : 'bg-slate-700/50 group-hover:bg-slate-600/50',
+    };
+    return classes[color] || classes.emerald;
+  };
+
+  const getZapClass = (color) => {
+    const classes = {
+      emerald: 'text-emerald-400',
+      amber: 'text-amber-400',
+      violet: 'text-violet-400',
+    };
+    return classes[color] || classes.emerald;
+  };
+
+  const getDotClass = (color) => {
+    const classes = {
+      emerald: 'bg-emerald-400',
+      amber: 'bg-amber-400',
+      violet: 'bg-violet-400',
+    };
+    return classes[color] || classes.emerald;
+  };
+
+  const formatTime = (seconds) => {
+    const hours = Math.floor(seconds / 3600);
+    const minutes = Math.floor((seconds % 3600) / 60);
+    if (hours > 0) {
+      return `${hours}h ${minutes}m`;
+    }
+    return `${minutes}m`;
+  };
+
+  // 진행률 계산
+  const progressPercentage = Math.min((studyTimer / targetTime) * 100, 100);
+
+  return (
+    <div className={`bg-slate-900/95 backdrop-blur-sm border-r border-slate-800/50 transition-all duration-300 flex flex-col flex-shrink-0 relative
+      ${isCollapsed ? 'w-16' : 'w-64'}`}>
+      
+      {/* Header - Focus Mode */}
+      <div className="p-4 border-b border-slate-800/50 flex-shrink-0">
+        <div className="flex items-center justify-between">
+          {!isCollapsed ? (
+            <div className="flex items-center gap-3">
+              <div className="w-8 h-8 rounded-xl bg-gradient-to-br from-emerald-500 via-teal-500 to-cyan-500 flex items-center justify-center shadow-lg relative">
+                <Sparkles size={16} className="text-white" />
+                {isStudying && (
+                  <div className="absolute -top-1 -right-1 w-3 h-3 bg-green-400 rounded-full animate-pulse"></div>
+                )}
+              </div>
+              <div>
+                <h1 className="text-lg font-bold text-white">Focus Mode</h1>
+                <p className="text-xs text-emerald-300 -mt-0.5 flex items-center gap-1">
+                  <Focus size={10} />
+                  {isStudying ? '집중 학습 중' : '집중 학습 환경'}
+                </p>
+              </div>
+            </div>
+          ) : (
+            <div className="w-8 h-8 rounded-xl bg-gradient-to-br from-emerald-500 via-teal-500 to-cyan-500 flex items-center justify-center shadow-lg mx-auto relative">
+              <Sparkles size={16} className="text-white" />
+              {isStudying && (
+                <div className="absolute -top-1 -right-1 w-3 h-3 bg-green-400 rounded-full animate-pulse"></div>
+              )}
+            </div>
+          )}
+          
+          {!isCollapsed && (
+            <button
+              onClick={onToggle}
+              className="p-2 text-slate-400 hover:text-slate-300 hover:bg-slate-800/50 rounded-lg transition-all duration-200"
+            >
+              <ChevronsLeft size={18} />
+            </button>
+          )}
+        </div>
+      </div>
+
+      {/* 자동 집중 타이머 - 강화된 UI */}
+      {!isCollapsed && (
+        <div className="p-4 border-b border-slate-800/30">
+          <div className="bg-slate-800/50 rounded-xl p-4 border border-emerald-500/50 shadow-lg shadow-emerald-500/20 transition-all duration-300">
+            <div className="flex items-center justify-between mb-3">
+              <div className="flex items-center gap-2">
+                <div className="p-1 rounded-lg bg-emerald-500/20 transition-all duration-300">
+                  <Timer size={16} className="text-emerald-400" />
+                </div>
+                <span className="text-sm font-medium text-white">학습 시간</span>
+              </div>
+              <div className="px-3 py-1 text-xs font-medium rounded-full bg-emerald-500/20 text-emerald-300 border border-emerald-500/30 transition-all duration-300">
+                <div className="flex items-center gap-2">
+                  <div className="w-2 h-2 bg-emerald-400 rounded-full animate-pulse"></div>
+                  <span>측정 중</span>
+                </div>
+              </div>
+            </div>
+            
+            {/* 실시간 시간 표시 - 더 큰 폰트와 애니메이션 */}
+            <div className="text-3xl font-bold mb-2 text-white transition-all duration-300">
+              {formatTime(studyTimer)}
+              <span className="text-lg text-emerald-300 ml-2 animate-pulse">●</span>
+            </div>
+            
+            {/* 진행률 바 */}
+            <div className="w-full bg-slate-700/50 rounded-full h-2 mb-2">
+              <div 
+                className={`h-2 rounded-full transition-all duration-1000 ${progressPercentage >= 100 
+                  ? 'bg-gradient-to-r from-emerald-500 to-green-400' 
+                  : 'bg-gradient-to-r from-emerald-500 to-teal-400'}`}
+                style={{ width: `${Math.min(progressPercentage, 100)}%` }}
+              ></div>
+            </div>
+            
+            {/* 목표 시간과 진행률 */}
+            <div className="flex items-center justify-between text-xs text-slate-400">
+              <span>목표: {formatTime(targetTime)}</span>
+              <span className={progressPercentage >= 100 ? 'text-emerald-300 font-medium' : ''}>
+                {Math.round(progressPercentage)}% 완료
+              </span>
+            </div>
+            
+            {/* 목표 달성 메시지 */}
+            {progressPercentage >= 100 && (
+              <div className="mt-3 p-2 bg-emerald-500/20 border border-emerald-500/30 rounded-lg">
+                <div className="text-xs text-emerald-300 font-medium animate-pulse flex items-center gap-2">
+                  <span>🎉</span>
+                  <span>목표 달성! 훌륭합니다!</span>
+                </div>
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+
+      {/* Navigation */}
+      <nav className="flex-1 p-1.5 overflow-y-auto">
+        <div className="space-y-2">
+          {studyNavItems.map((item) => {
+            const isActive = activeView === item.id;
+            return (
+              <button
+                key={item.id}
+                onClick={() => onViewChange(item.id)}
+                className={`group w-full flex items-center gap-3 px-3 py-3 rounded-xl text-sm font-medium transition-all duration-300 relative
+                  ${getColorClasses(item.color, isActive)}
+                  ${isActive ? 'transform scale-[1.02]' : 'hover:transform hover:scale-[1.01]'}
+                `}
+              >
+                <div className={`flex-shrink-0 p-2 rounded-lg transition-all duration-200 ${
+                  getIconBgClass(item.color, isActive)
+                } ${isCollapsed ? 'mx-auto' : ''}`}>
+                  <item.icon size={16} />
+                </div>
+                
+                {!isCollapsed && (
+                  <div className="flex-1 text-left">
+                    <div className="flex items-center justify-between">
+                      <span className="font-medium">{item.label}</span>
+                      {isActive && (
+                        <div className="flex items-center gap-1">
+                          <Zap size={12} className={`animate-pulse ${getZapClass(item.color)}`} />
+                          <div className={`w-2 h-2 rounded-full animate-pulse ${getDotClass(item.color)}`}></div>
+                        </div>
+                      )}
+                    </div>
+                    <p className="text-xs text-slate-400 mt-0.5">{item.description}</p>
+                    {/* 컨텐츠 뷰일 때 자동 측정 표시 */}
+                    {item.id === 'content' && isActive && isStudying && (
+                      <p className="text-xs text-emerald-300 mt-1 flex items-center gap-1">
+                        <div className="w-1.5 h-1.5 bg-emerald-400 rounded-full animate-pulse"></div>
+                        자동 시간 측정 중
+                      </p>
+                    )}
+                  </div>
+                )}
+                
+                {isCollapsed && isActive && (
+                  <div className="absolute right-0 top-1/2 transform -translate-y-1/2 w-1 h-6 bg-emerald-400 rounded-l-full"></div>
+                )}
+              </button>
+            );
+          })}
+        </div>
+
+        {/* Study Stats */}
+        {!isCollapsed && (
+          <>
+            <div className="my-6 border-t border-slate-800/50"></div>
+            <div className="space-y-3">
+              <h3 className="text-xs font-semibold text-slate-400 uppercase tracking-wider px-3">실시간 통계</h3>
+              <div className="space-y-2">
+                <div className="flex items-center justify-between px-3 py-2 bg-slate-800/30 rounded-lg">
+                  <div className="flex items-center gap-2">
+                    <Target size={14} className="text-blue-400" />
+                    <span className="text-sm text-slate-300">오늘 목표</span>
+                  </div>
+                  <span className={`text-sm font-medium ${
+                    progressPercentage >= 100 ? 'text-emerald-300' : 'text-blue-300'
+                  }`}>
+                    {Math.round(progressPercentage)}%
+                  </span>
+                </div>
+                <div className="flex items-center justify-between px-3 py-2 bg-slate-800/30 rounded-lg">
+                  <div className="flex items-center gap-2">
+                    <Zap size={14} className="text-amber-400" />
+                    <span className="text-sm text-slate-300">집중 시간</span>
+                  </div>
+                  <span className="text-sm font-medium flex items-center gap-1 text-amber-300">
+                    {formatTime(studyTimer)}
+                    <div className="w-1.5 h-1.5 bg-amber-400 rounded-full animate-pulse"></div>
+                  </span>
+                </div>
+              </div>
+            </div>
+          </>
+        )}
+      </nav>
+
+      {/* Back to Main & Collapse Button */}
+      <div className="p-4 border-t border-slate-800/50 flex-shrink-0">
+        {!isCollapsed ? (
+          <div className="flex gap-2">
+            <button className="flex-1 flex items-center justify-center gap-2 py-2.5 px-3 bg-slate-800/50 hover:bg-slate-700/50 text-slate-300 rounded-lg transition-all duration-200 text-sm font-medium">
+              <ArrowLeft size={14} />
+              메인으로
+            </button>
+          </div>
+        ) : (
+          <button
+            onClick={onToggle}
+            className="w-full p-2.5 text-slate-400 hover:text-slate-300 hover:bg-slate-800/50 rounded-lg transition-all duration-200"
+          >
+            <Menu size={18} />
+          </button>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default StudySidebar;

--- a/src/components/layout/TextbookStudyHeader.js
+++ b/src/components/layout/TextbookStudyHeader.js
@@ -1,0 +1,262 @@
+import React, { useState } from 'react';
+import { 
+  Search, Settings, NotebookPen, Eye, BookOpen, FileDown, 
+  ZoomIn, ZoomOut, RotateCw, List, ChevronLeft, ChevronRight,
+  Play, Pause, Timer, Target, Star, Menu, X
+} from 'lucide-react';
+
+const TextbookStudyHeader = () => {
+  const [isStudying, setIsStudying] = useState(true);
+  const [showSettingsMenu, setShowSettingsMenu] = useState(false);
+  const [isNotePanelVisible, setIsNotePanelVisible] = useState(false);
+  const [viewMode, setViewMode] = useState('pdf');
+  const [currentPage, setCurrentPage] = useState(4);
+  const [numPages, setNumPages] = useState(1035);
+  const [scale, setScale] = useState(180);
+  const [studyTimer, setStudyTimer] = useState(3847); // 1시간 4분 7초
+  
+  // 샘플 데이터
+  const textbookData = {
+    title: "컴파일러 - Compilers: Principles, Techniques, and Tools",
+    author: "Alfred V. Aho, Monica S. Lam, Ravi Sethi, Jeffrey D. Ullman",
+    publisher: "Pearson",
+    progress: Math.round((currentPage / numPages) * 100)
+  };
+
+  const formatTime = (seconds) => {
+    const hours = Math.floor(seconds / 3600);
+    const mins = Math.floor((seconds % 3600) / 60);
+    const secs = seconds % 60;
+    
+    if (hours > 0) {
+      return `${hours.toString().padStart(2, '0')}:${mins.toString().padStart(2, '0')}:${secs.toString().padStart(2, '0')}`;
+    }
+    return `${mins.toString().padStart(2, '0')}:${secs.toString().padStart(2, '0')}`;
+  };
+
+  const getShortTitle = (title) => {
+    if (!title) return '';
+    const shortTitle = title.split(/[-–—]/)[0].trim();
+    if (shortTitle.length > 25) {
+      return shortTitle.substring(0, 25) + '...';
+    }
+    return shortTitle;
+  };
+
+  const getChapterInfo = (page) => {
+    return `chap1.p${page}`;
+  };
+
+  const zoomIn = () => setScale(prev => Math.min(prev + 10, 300));
+  const zoomOut = () => setScale(prev => Math.max(prev - 10, 50));
+
+  return (
+    <div className="bg-white shadow-sm border-b border-gray-100">
+      {/* 메인 헤더 - 모든 정보를 한 줄에 통합 */}
+      <div className="px-6 py-4">
+        <div className="flex items-center justify-between">
+          {/* 왼쪽: 원서 정보 및 학습 상태 */}
+          <div className="flex items-center space-x-6">
+            {/* 원서 기본 정보 */}
+            <div className="flex flex-col">
+              <div className="flex items-center space-x-3">
+                <h1 className="text-xl font-bold text-gray-900" title={textbookData.title}>
+                  {getShortTitle(textbookData.title)}
+                </h1>
+                <div className="flex items-center space-x-2">
+                  <span className="text-xs bg-blue-100 text-blue-800 px-2 py-1 rounded-full font-medium">
+                    {getChapterInfo(currentPage)}
+                  </span>
+                  <span className="text-xs bg-gray-100 text-gray-600 px-2 py-1 rounded-full">
+                    {textbookData.progress}% 완료
+                  </span>
+                </div>
+              </div>
+              <div className="flex items-center space-x-4 mt-1 text-sm text-gray-600">
+                <span className="truncate max-w-[200px]" title={textbookData.author}>
+                  {textbookData.author.split(',')[0].trim()}
+                </span>
+                <span className="text-gray-400">•</span>
+                <span className="text-gray-500 truncate max-w-[120px]" title={textbookData.publisher}>
+                  {textbookData.publisher}
+                </span>
+              </div>
+            </div>
+
+            {/* 학습 타이머 */}
+            <div className="flex items-center space-x-2 bg-gradient-to-r from-green-50 to-emerald-50 px-4 py-2.5 rounded-xl border border-green-200">
+              <div className={`w-2 h-2 rounded-full ${isStudying ? 'bg-green-500 animate-pulse' : 'bg-gray-400'}`}></div>
+              <Timer className="w-4 h-4 text-green-600" />
+              <span className="text-sm font-mono text-green-700">
+                {formatTime(studyTimer)}
+              </span>
+              <button
+                onClick={() => setIsStudying(!isStudying)}
+                className="ml-2 p-1 hover:bg-green-100 rounded-md transition-colors"
+                title={isStudying ? "학습 일시정지" : "학습 시작"}
+              >
+                {isStudying ? (
+                  <Pause className="w-4 h-4 text-green-600" />
+                ) : (
+                  <Play className="w-4 h-4 text-green-600" />
+                )}
+              </button>
+            </div>
+          </div>
+
+          {/* 오른쪽: 컨트롤 버튼들 */}
+          <div className="flex items-center space-x-2">
+            {/* PDF 컨트롤 그룹 */}
+            <div className="flex items-center space-x-1 bg-gray-50 rounded-lg p-1">
+              <button 
+                onClick={zoomOut}
+                className="p-2 text-gray-600 hover:text-gray-900 hover:bg-white rounded-md transition-colors"
+                title="축소"
+              >
+                <ZoomOut className="w-4 h-4" />
+              </button>
+              <span className="text-xs text-gray-600 px-2 py-1 bg-white rounded-md font-mono min-w-[45px] text-center">
+                {scale}%
+              </span>
+              <button 
+                onClick={zoomIn}
+                className="p-2 text-gray-600 hover:text-gray-900 hover:bg-white rounded-md transition-colors"
+                title="확대"
+              >
+                <ZoomIn className="w-4 h-4" />
+              </button>
+            </div>
+
+            {/* 페이지 네비게이션 */}
+            <div className="flex items-center space-x-1 bg-gray-50 rounded-lg p-1">
+              <button 
+                className="p-2 text-gray-600 hover:text-gray-900 hover:bg-white rounded-md transition-colors disabled:opacity-50"
+                disabled={currentPage <= 1}
+                title="이전 페이지"
+              >
+                <ChevronLeft className="w-4 h-4" />
+              </button>
+              <div className="flex items-center space-x-1 bg-white rounded-md px-3 py-2">
+                <input
+                  type="number"
+                  value={currentPage}
+                  onChange={(e) => setCurrentPage(Number(e.target.value))}
+                  className="w-12 text-xs text-center border-none outline-none font-mono"
+                  min="1"
+                  max={numPages}
+                />
+                <span className="text-xs text-gray-400">/</span>
+                <span className="text-xs text-gray-600 font-mono">{numPages}</span>
+              </div>
+              <button 
+                className="p-2 text-gray-600 hover:text-gray-900 hover:bg-white rounded-md transition-colors disabled:opacity-50"
+                disabled={currentPage >= numPages}
+                title="다음 페이지"
+              >
+                <ChevronRight className="w-4 h-4" />
+              </button>
+            </div>
+
+            {/* 구분선 */}
+            <div className="w-px h-8 bg-gray-200"></div>
+
+            {/* 기능 버튼 그룹 */}
+            <div className="flex items-center space-x-1">
+              <button 
+                className="p-2.5 text-gray-600 hover:text-gray-900 hover:bg-gray-100 rounded-lg transition-colors"
+                title="검색"
+              >
+                <Search className="w-5 h-5" />
+              </button>
+              
+              <button 
+                onClick={() => setViewMode(viewMode === 'toc' ? 'pdf' : 'toc')}
+                className={`p-2.5 rounded-lg transition-colors ${
+                  viewMode === 'toc' 
+                    ? 'bg-blue-600 text-white shadow-sm' 
+                    : 'text-gray-600 hover:text-gray-900 hover:bg-gray-100'
+                }`}
+                title="목차"
+              >
+                <List className="w-5 h-5" />
+              </button>
+
+              <button 
+                onClick={() => setIsNotePanelVisible(!isNotePanelVisible)}
+                className={`p-2.5 rounded-lg transition-colors ${
+                  isNotePanelVisible 
+                    ? 'bg-blue-600 text-white shadow-sm' 
+                    : 'text-gray-600 hover:text-gray-900 hover:bg-gray-100'
+                }`}
+                title="노트 패널"
+              >
+                <NotebookPen className="w-5 h-5" />
+              </button>
+
+              {/* 설정 메뉴 */}
+              <div className="relative">
+                <button 
+                  onClick={() => setShowSettingsMenu(!showSettingsMenu)}
+                  className="p-2.5 text-gray-600 hover:text-gray-900 hover:bg-gray-100 rounded-lg transition-colors"
+                  title="설정"
+                >
+                  <Settings className="w-5 h-5" />
+                </button>
+                
+                {showSettingsMenu && (
+                  <div className="absolute right-0 top-full mt-2 w-64 bg-white rounded-xl shadow-xl border border-gray-200 z-50">
+                    <div className="p-2">
+                      <button className="w-full flex items-center space-x-3 px-4 py-3 text-sm text-gray-700 hover:bg-gray-50 rounded-lg transition-colors">
+                        <FileDown className="w-4 h-4" />
+                        <div className="flex-1 text-left">
+                          <div className="font-medium">PDF 다운로드</div>
+                          <div className="text-xs text-gray-500">메모와 노트 포함</div>
+                        </div>
+                      </button>
+                      
+                      <div className="border-t border-gray-100 my-2"></div>
+                      
+                      <button className="w-full flex items-center space-x-3 px-4 py-3 text-sm text-gray-700 hover:bg-gray-50 rounded-lg transition-colors">
+                        <Target className="w-4 h-4" />
+                        <div className="flex-1 text-left">
+                          <div className="font-medium">학습 목표 설정</div>
+                          <div className="text-xs text-gray-500">일일 학습량 조정</div>
+                        </div>
+                      </button>
+                      
+                      <button className="w-full flex items-center space-x-3 px-4 py-3 text-sm text-gray-700 hover:bg-gray-50 rounded-lg transition-colors">
+                        <Star className="w-4 h-4" />
+                        <div className="flex-1 text-left">
+                          <div className="font-medium">북마크 관리</div>
+                          <div className="text-xs text-gray-500">중요 페이지 저장</div>
+                        </div>
+                      </button>
+                    </div>
+                  </div>
+                )}
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* 프로그레스 바 - 매우 얇게 */}
+      <div className="h-1 bg-gray-100">
+        <div 
+          className="h-full bg-gradient-to-r from-blue-500 via-blue-600 to-indigo-600 transition-all duration-300"
+          style={{ width: `${textbookData.progress}%` }}
+        />
+      </div>
+
+      {/* 설정 메뉴 백그라운드 클릭으로 닫기 */}
+      {showSettingsMenu && (
+        <div 
+          className="fixed inset-0 z-40" 
+          onClick={() => setShowSettingsMenu(false)}
+        />
+      )}
+    </div>
+  );
+};
+
+export default TextbookStudyHeader;

--- a/src/components/notes/NotePanel.js
+++ b/src/components/notes/NotePanel.js
@@ -1,319 +1,436 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useMemo, useCallback } from 'react';
 import { Plus, X, Edit3, Trash2, Hash, FileText, Lightbulb as LightbulbIcon, AlertCircle, Star, NotebookPen, Search} from 'lucide-react';
 
 // 노트 에디터 컴포넌트
-const NoteEditor = ({ note, onSave, onCancel, isNew = false, currentPage = 1, selectedText = '' }) => {
-    const [title, setTitle] = useState(note?.title || selectedText || '');
-    const [content, setContent] = useState(note?.content || '');
-    const [tags, setTags] = useState(note?.tags || []);
-    const [color, setColor] = useState(note?.color || 'blue');
-    const [tagInput, setTagInput] = useState('');
-    const [noteType, setNoteType] = useState(note?.type || 'memo');
-  
-    const noteColors = [
-      { name: 'Blue', value: 'blue', bg: 'bg-blue-50', border: 'border-blue-200', text: 'text-blue-900' },
-      { name: 'Green', value: 'green', bg: 'bg-green-50', border: 'border-green-200', text: 'text-green-900' },
-      { name: 'Yellow', value: 'yellow', bg: 'bg-yellow-50', border: 'border-yellow-200', text: 'text-yellow-900' },
-      { name: 'Purple', value: 'purple', bg: 'bg-purple-50', border: 'border-purple-200', text: 'text-purple-900' },
-      { name: 'Red', value: 'red', bg: 'bg-red-50', border: 'border-red-200', text: 'text-red-900' },
-      { name: 'Gray', value: 'gray', bg: 'bg-gray-50', border: 'border-gray-200', text: 'text-gray-900' }
-    ];
-  
-    const noteTypes = [
-      { value: 'note', label: '일반 노트', icon: FileText },
-      { value: 'concept', label: '개념 정리', icon: LightbulbIcon },
-      { value: 'question', label: '질문', icon: AlertCircle },
-      { value: 'important', label: '중요 내용', icon: Star },
-    ];
-  
-    const addTag = () => {
-      if (tagInput.trim() && !tags.includes(tagInput.trim())) {
-        setTags([...tags, tagInput.trim()]);
-        setTagInput('');
+const NoteEditor = ({ note, onSave, onCancel, isNew = false, currentPage = 1, selectedText = '', getChapterInfo }) => {
+  const [title, setTitle] = useState(note?.title || selectedText || '');
+  const [content, setContent] = useState(note?.content || '');
+  const [tags, setTags] = useState(note?.tags || []);
+  const [color, setColor] = useState(note?.color || 'blue');
+  const [tagInput, setTagInput] = useState('');
+  const [noteType, setNoteType] = useState(note?.type || 'note');
+
+  const noteColors = [
+    { name: 'Blue', value: 'blue', bg: 'bg-blue-50', border: 'border-blue-200', text: 'text-blue-900' },
+    { name: 'Green', value: 'green', bg: 'bg-green-50', border: 'border-green-200', text: 'text-green-900' },
+    { name: 'Yellow', value: 'yellow', bg: 'bg-yellow-50', border: 'border-yellow-200', text: 'text-yellow-900' },
+    { name: 'Purple', value: 'purple', bg: 'bg-purple-50', border: 'border-purple-200', text: 'text-purple-900' },
+    { name: 'Red', value: 'red', bg: 'bg-red-50', border: 'border-red-200', text: 'text-red-900' },
+    { name: 'Gray', value: 'gray', bg: 'bg-gray-50', border: 'border-gray-200', text: 'text-gray-900' }
+  ];
+
+  const noteTypes = [
+    { value: 'note', label: '일반 노트', icon: FileText },
+    { value: 'concept', label: '개념 정리', icon: LightbulbIcon },
+    { value: 'question', label: '질문', icon: AlertCircle },
+    { value: 'important', label: '중요 내용', icon: Star },
+  ];
+
+  const addTag = () => {
+    if (tagInput.trim() && !tags.includes(tagInput.trim())) {
+      setTags([...tags, tagInput.trim()]);
+      setTagInput('');
+    }
+  };
+
+  const removeTag = (tagToRemove) => {
+    setTags(tags.filter(tag => tag !== tagToRemove));
+  };
+
+  const handleSave = () => {
+    const noteData = {
+      ...note,
+      title: title || '제목 없음',
+      content,
+      tags,
+      color,
+      type: noteType,
+      page: currentPage,
+      updatedAt: new Date().toISOString(),
+      ...(isNew && { id: Date.now(), createdAt: new Date().toISOString() })
+    };
+    onSave(noteData);
+  };
+
+  const selectedColor = noteColors.find(c => c.value === color) || noteColors[0];
+
+  // 페이지 정보 메모이제이션 - getChapterInfo 호출 최소화
+  const pageInfo = useMemo(() => {
+    if (getChapterInfo && typeof getChapterInfo === 'function') {
+      try {
+        return getChapterInfo(currentPage);
+      } catch (error) {
+        console.warn('챕터 정보 가져오기 실패:', error);
+        return `P.${currentPage}`;
       }
-    };
-  
-    const removeTag = (tagToRemove) => {
-      setTags(tags.filter(tag => tag !== tagToRemove));
-    };
-  
-    const handleSave = () => {
-      const noteData = {
-        ...note,
-        title: title || '제목 없음',
-        content,
-        tags,
-        color,
-        type: noteType,
-        page: currentPage,
-        updatedAt: new Date().toISOString(),
-        ...(isNew && { id: Date.now(), createdAt: new Date().toISOString() })
-      };
-      onSave(noteData);
-    };
-  
-    const selectedColor = noteColors.find(c => c.value === color) || noteColors[0];
-  
-    return (
-      <div className={`${selectedColor.bg} ${selectedColor.border} border rounded-xl p-4 mb-4`}>
-        <div className="space-y-4">
-          {/* 페이지 정보 표시 */}
+    }
+    return `P.${currentPage}`;
+  }, [getChapterInfo, currentPage]);
+
+  return (
+    <div className={`${selectedColor.bg} ${selectedColor.border} border rounded-xl p-3 sm:p-4 mb-4`}>
+      <div className="space-y-3 sm:space-y-4">
+        {/* 페이지 정보 및 타입 선택 */}
+        <div className="flex flex-col gap-3">
           <div className="flex items-center justify-between">
-            <div className="flex items-center space-x-2">
-              <span className="inline-block bg-gray-100 text-blue-700 px-2 py-0.5 rounded text-sm font-medium">
-                P.{currentPage}
-              </span>
-              <select
-                value={noteType}
-                onChange={(e) => setNoteType(e.target.value)}
-                className="text-sm bg-white border border-gray-300 rounded-lg px-3 py-1.5 focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-              >
-                {noteTypes.map(type => (
-                  <option key={type.value} value={type.value}>{type.label}</option>
-                ))}
-              </select>
-            </div>
-            <div className="flex items-center space-x-1">
+            <span className="inline-block bg-gradient-to-r from-blue-500 to-blue-600 text-white px-2 sm:px-3 py-1 rounded-full text-xs sm:text-sm font-medium shadow-sm max-w-[100px] sm:max-w-[140px] truncate" title={pageInfo}>
+              {pageInfo}
+            </span>
+            <select 
+              value={noteType} 
+              onChange={(e) => setNoteType(e.target.value)}
+              className="text-xs sm:text-sm bg-white border border-gray-300 rounded-lg px-2 sm:px-3 py-1 sm:py-1.5 focus:ring-2 focus:ring-blue-500 focus:border-transparent shadow-sm max-w-[120px] sm:max-w-none"
+            >
+              {noteTypes.map(type => (
+                <option key={type.value} value={type.value}>{type.label}</option>
+              ))}
+            </select>
+          </div>
+          
+          {/* 색상 선택 - 더 작고 컴팩트하게 */}
+          <div className="flex items-center justify-left">
+            <div className="flex items-center space-x-1 bg-white bg-opacity-50 rounded-lg px-2 py-1">
               {noteColors.map(colorOption => (
                 <button
                   key={colorOption.value}
                   onClick={() => setColor(colorOption.value)}
-                  className={`w-6 h-6 rounded-full ${colorOption.bg} ${colorOption.border} border-2 hover:scale-110 transition-transform ${
-                    color === colorOption.value ? 'ring-2 ring-gray-400' : ''
+                  className={`w-4 h-4 rounded-full ${colorOption.bg} ${colorOption.border} border hover:scale-110 transition-transform shadow-sm ${
+                    color === colorOption.value ? 'ring-1 ring-gray-400' : ''
                   }`}
+                  title={colorOption.name}
                 />
               ))}
             </div>
           </div>
-          {/* 제목 입력 */}
-          <div>
-            <input
-              type="text"
-              value={title}
-              onChange={(e) => setTitle(e.target.value)}
-              placeholder="노트 제목을 입력하세요..."
-              className="w-full text-lg font-semibold bg-transparent border-none outline-none placeholder-gray-500"
-            />
-          </div>
-          {/* 내용 입력 */}
-          <div>
-            <textarea
-              value={content}
-              onChange={(e) => setContent(e.target.value)}
-              placeholder="내용을 입력하세요..."
-              className="w-full h-40 bg-transparent border-none outline-none resize-none placeholder-gray-500 text-sm leading-relaxed"
-            />
-          </div>
-          {/* 태그 입력 */}
-          <div>
-            <div className="flex flex-wrap gap-1 mb-2">
-              {tags.map(tag => (
-                <span
-                  key={tag}
-                  className="inline-flex items-center px-2 py-1 text-xs bg-white bg-opacity-70 rounded-full"
-                >
-                  <Hash className="w-3 h-3 mr-1" />
-                  {tag}
-                  <button
-                    onClick={() => removeTag(tag)}
-                    className="ml-1 hover:text-red-500"
-                  >
-                    <X className="w-3 h-3" />
-                  </button>
-                </span>
-              ))}
-            </div>
-            <div className="flex space-x-2">
-              <input
-                type="text"
-                value={tagInput}
-                onChange={(e) => setTagInput(e.target.value)}
-                onKeyPress={(e) => e.key === 'Enter' && addTag()}
-                placeholder="태그 추가..."
-                className="flex-1 text-xs bg-white bg-opacity-50 border border-white border-opacity-50 rounded-lg px-2 py-1 focus:ring-1 focus:ring-white focus:border-transparent"
-              />
-              <button
-                onClick={addTag}
-                className="px-3 py-1 text-xs bg-white bg-opacity-70 hover:bg-opacity-90 rounded-lg transition-colors"
-              >
-                추가
-              </button>
-            </div>
-          </div>
-          {/* 액션 버튼 */}
-          <div className="flex space-x-2 pt-2">
-            <button
-              onClick={handleSave}
-              className="flex-1 bg-white bg-opacity-80 hover:bg-opacity-100 text-sm font-medium py-2 rounded-lg transition-colors"
-            >
-              저장
-            </button>
-            <button
-              onClick={onCancel}
-              className="px-4 bg-white bg-opacity-60 hover:bg-opacity-80 text-sm py-2 rounded-lg transition-colors"
-            >
-              취소
-            </button>
-          </div>
         </div>
-      </div>
-    );
-  };
-  
-  // 노트 카드 컴포넌트
-  const NoteCard = ({ note, onEdit, onDelete }) => {
-    const noteColors = {
-      blue: { bg: 'bg-blue-50', border: 'border-blue-200', text: 'text-blue-900' },
-      green: { bg: 'bg-green-50', border: 'border-green-200', text: 'text-green-900' },
-      yellow: { bg: 'bg-yellow-50', border: 'border-yellow-200', text: 'text-yellow-900' },
-      purple: { bg: 'bg-purple-50', border: 'border-purple-200', text: 'text-purple-900' },
-      red: { bg: 'bg-red-50', border: 'border-red-200', text: 'text-red-900' },
-      gray: { bg: 'bg-gray-50', border: 'border-gray-200', text: 'text-gray-900' }
-    };
-  
-    const noteTypes = {
-      note: { label: '일반 노트', icon: FileText, color: 'text-blue-500' },
-      concept: { label: '개념 정리', icon: LightbulbIcon, color: 'text-yellow-500' },
-      question: { label: '질문', icon: AlertCircle, color: 'text-red-500' },
-      important: { label: '중요 내용', icon: Star, color: 'text-purple-500' },
-    };
-  
-    const colorScheme = noteColors[note.color] || noteColors.blue;
-    const typeInfo = noteTypes[note.type] || noteTypes.note;
-    const TypeIcon = typeInfo.icon;
-  
-    const formatDate = (dateString) => {
-      const date = new Date(dateString);
-      const now = new Date();
-      const diff = now - date;
-      const hours = diff / (1000 * 60 * 60);
-      if (hours < 1) return '방금 전';
-      if (hours < 24) return `${Math.floor(hours)}시간 전`;
-      if (hours < 168) return `${Math.floor(hours / 24)}일 전`;
-      return date.toLocaleDateString('ko-KR');
-    };
-  
-    return (
-      <div className={`${colorScheme.bg} ${colorScheme.border} border rounded-xl p-4 mb-3 group hover:shadow-sm transition-shadow`}>
-        <div className="flex items-start justify-between mb-2">
-          <div className="flex items-center space-x-2">
-            <TypeIcon className={`w-4 h-4 ${typeInfo.color}`} />
-            <span className={`text-xs font-medium ${colorScheme.text} opacity-75`}>
-              {typeInfo.label}
-            </span>
-          </div>
-          <div className="flex items-center space-x-1 opacity-0 group-hover:opacity-100 transition-opacity">
-            <button
-              onClick={() => onEdit(note)}
-              className="p-1 hover:bg-white hover:bg-opacity-50 rounded transition-colors"
-            >
-              <Edit3 className="w-4 h-4 text-gray-500" />
-            </button>
-            <button
-              onClick={() => onDelete(note.id)}
-              className="p-1 hover:bg-white hover:bg-opacity-50 rounded transition-colors"
-            >
-              <Trash2 className="w-4 h-4 text-gray-500" />
-            </button>
-          </div>
+
+        {/* 제목 입력 */}
+        <div>
+          <input
+            type="text"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            placeholder="노트 제목을 입력하세요..."
+            className="w-full text-base sm:text-lg font-semibold bg-transparent border-none outline-none placeholder-gray-500"
+          />
         </div>
-        <h3 className={`font-semibold ${colorScheme.text} mb-2 text-sm`}>
-          <span className="inline-block bg-gray-100 text-blue-700 px-2 py-0.5 rounded mr-2">P.{note.page}</span>
-          {note.title}
-        </h3>
-        <p className={`${colorScheme.text} opacity-75 text-sm leading-relaxed mb-3 line-clamp-3`}>
-          {note.content}
-        </p>
-        {note.tags && note.tags.length > 0 && (
+
+        {/* 내용 입력 */}
+        <div>
+          <textarea
+            value={content}
+            onChange={(e) => setContent(e.target.value)}
+            placeholder="내용을 입력하세요..."
+            className="w-full h-32 sm:h-40 bg-transparent border-none outline-none resize-none placeholder-gray-500 text-sm leading-relaxed"
+          />
+        </div>
+
+        {/* 태그 */}
+        <div>
           <div className="flex flex-wrap gap-1 mb-2">
-            {note.tags.map(tag => (
-              <span
-                key={tag}
-                className="inline-flex items-center px-2 py-0.5 text-xs bg-white bg-opacity-60 rounded-full"
-              >
-                <Hash className="w-2.5 h-2.5 mr-0.5" />
-                {tag}
+            {tags.map(tag => (
+              <span key={tag} className="inline-flex items-center px-2 py-1 text-xs bg-white bg-opacity-70 rounded-full shadow-sm">
+                <Hash className="w-3 h-3 mr-1" />
+                <span className="max-w-[80px] truncate">{tag}</span>
+                <button
+                  onClick={() => removeTag(tag)}
+                  className="ml-1 hover:text-red-500 transition-colors"
+                >
+                  <X className="w-3 h-3" />
+                </button>
               </span>
             ))}
           </div>
-        )}
-        <div className={`text-xs ${colorScheme.text} opacity-50`}>
-          {formatDate(note.updatedAt || note.createdAt)}
+          <div className="flex space-x-2">
+            <input
+              type="text"
+              value={tagInput}
+              onChange={(e) => setTagInput(e.target.value)}
+              onKeyPress={(e) => e.key === 'Enter' && addTag()}
+              placeholder="태그 추가..."
+              className="flex-1 text-xs bg-white bg-opacity-60 border border-gray-200 rounded-lg px-2 py-1 focus:ring-1 focus:ring-blue-400 focus:border-blue-300 shadow-sm"
+            />
+            <button
+              onClick={addTag}
+              className="px-3 py-1 text-xs bg-white bg-opacity-80 hover:bg-opacity-100 rounded-lg transition-colors shadow-sm whitespace-nowrap"
+            >
+              추가
+            </button>
+          </div>
+        </div>
+
+        {/* 저장/취소 버튼 */}
+        <div className="flex space-x-2 pt-2">
+          <button
+            onClick={handleSave}
+            className="flex-1 bg-white bg-opacity-90 hover:bg-opacity-100 text-sm font-medium py-2 rounded-lg transition-colors shadow-sm"
+          >
+            저장
+          </button>
+          <button
+            onClick={onCancel}
+            className="px-4 bg-white bg-opacity-70 hover:bg-opacity-90 text-sm py-2 rounded-lg transition-colors shadow-sm"
+          >
+            취소
+          </button>
         </div>
       </div>
-    );
+    </div>
+  );
+};
+
+// 노트 카드 컴포넌트 - 메모이제이션 적용
+const NoteCard = React.memo(({ note, onEdit, onDelete, getChapterInfo }) => {
+  const noteColors = {
+    blue: { bg: 'bg-blue-50', border: 'border-blue-200', text: 'text-blue-900' },
+    green: { bg: 'bg-green-50', border: 'border-green-200', text: 'text-green-900' },
+    yellow: { bg: 'bg-yellow-50', border: 'border-yellow-200', text: 'text-yellow-900' },
+    purple: { bg: 'bg-purple-50', border: 'border-purple-200', text: 'text-purple-900' },
+    red: { bg: 'bg-red-50', border: 'border-red-200', text: 'text-red-900' },
+    gray: { bg: 'bg-gray-50', border: 'border-gray-200', text: 'text-gray-900' }
   };
-  
-  // 노트 패널 컴포넌트 (개선된 버전)
-  const NotePanel = ({
-    isVisible,
-    onToggle,
-    notes: externalNotes = [],
-    selectedText = '',
-    currentPage = 1,
-    shouldOpenEditor = false,
-    onEditorOpened,
-    onNoteSave
-  }) => {
-    const [notes, setNotes] = useState([]);
-    const [editingNote, setEditingNote] = useState(null);
-    const [isCreating, setIsCreating] = useState(false);
-    const [searchTerm, setSearchTerm] = useState('');
-    const [filterType, setFilterType] = useState('all');
-    const [sortBy, setSortBy] = useState('date');
 
-    useEffect(() => {
-      setNotes(externalNotes);
-    }, [externalNotes]);
+  const noteTypes = {
+    note: { label: '일반 노트', icon: FileText, color: 'text-blue-500' },
+    concept: { label: '개념 정리', icon: LightbulbIcon, color: 'text-yellow-500' },
+    question: { label: '질문', icon: AlertCircle, color: 'text-red-500' },
+    important: { label: '중요 내용', icon: Star, color: 'text-purple-500' },
+  };
 
-    useEffect(() => {
-      if (shouldOpenEditor) {
-        setIsCreating(true);
-        onEditorOpened?.();
+  const colorScheme = noteColors[note.color] || noteColors.blue;
+  const typeInfo = noteTypes[note.type] || noteTypes.note;
+  const TypeIcon = typeInfo.icon;
+
+  const formatDate = (dateString) => {
+    const date = new Date(dateString);
+    const now = new Date();
+    const diff = now - date;
+    const hours = diff / (1000 * 60 * 60);
+
+    if (hours < 1) return '방금 전';
+    if (hours < 24) return `${Math.floor(hours)}시간 전`;
+    if (hours < 168) return `${Math.floor(hours / 24)}일 전`;
+    return date.toLocaleDateString('ko-KR');
+  };
+
+  // 페이지 정보 메모이제이션
+  const pageInfo = useMemo(() => {
+    if (getChapterInfo && typeof getChapterInfo === 'function') {
+      try {
+        return getChapterInfo(note.page);
+      } catch (error) {
+        console.warn('챕터 정보 가져오기 실패:', error);
+        return `P.${note.page}`;
       }
-    }, [shouldOpenEditor, onEditorOpened]);
+    }
+    return `P.${note.page}`;
+  }, [getChapterInfo, note.page]);
 
-    const handleSaveNote = (noteData) => {
-      if (editingNote) {
-        // 기존 노트 수정
-        const updatedNotes = notes.map(note => 
-          note.id === editingNote.id ? { ...note, ...noteData } : note
-        );
-        setNotes(updatedNotes);
-        setEditingNote(null);
-      } else {
-        // 새 노트 생성
-        const newNote = { ...noteData, id: Date.now() };
-        setNotes([newNote, ...notes]);
-        setIsCreating(false);
+  return (
+    <div className={`${colorScheme.bg} ${colorScheme.border} border rounded-xl p-3 sm:p-4 mb-3 group hover:shadow-md transition-all duration-200`}>
+      <div className="flex items-start justify-between mb-2">
+        <div className="flex items-center space-x-2 min-w-0 flex-1">
+          <TypeIcon className={`w-4 h-4 ${typeInfo.color} flex-shrink-0`} />
+          <span className={`text-xs font-medium ${colorScheme.text} opacity-75 truncate`}>
+            {typeInfo.label}
+          </span>
+        </div>
+        <div className="flex items-center space-x-1 opacity-0 group-hover:opacity-100 transition-opacity flex-shrink-0">
+          <button
+            onClick={() => onEdit(note)}
+            className="p-1 hover:bg-white hover:bg-opacity-70 rounded transition-colors"
+          >
+            <Edit3 className="w-4 h-4 text-gray-500" />
+          </button>
+          <button
+            onClick={() => onDelete(note.id)}
+            className="p-1 hover:bg-white hover:bg-opacity-70 rounded transition-colors"
+          >
+            <Trash2 className="w-4 h-4 text-gray-500" />
+          </button>
+        </div>
+      </div>
+
+      <div className="mb-2">
+        <div className="flex flex-wrap items-center gap-2 mb-1">
+          <span className="inline-block bg-gradient-to-r from-blue-500 to-blue-600 text-white px-2 sm:px-3 py-1 rounded-full text-xs font-medium shadow-sm max-w-[120px] sm:max-w-xs truncate" title={pageInfo}>
+            {pageInfo}
+          </span>
+        </div>
+        <h3 className={`font-semibold ${colorScheme.text} text-sm break-words`}>
+          {note.title}
+        </h3>
+      </div>
+
+      <p className={`${colorScheme.text} opacity-75 text-sm leading-relaxed mb-3 break-words`}>
+        {note.content.length > 150 ? `${note.content.substring(0, 150)}...` : note.content}
+      </p>
+
+      {note.tags && note.tags.length > 0 && (
+        <div className="flex flex-wrap gap-1 mb-2">
+          {note.tags.slice(0, 3).map(tag => (
+            <span key={tag} className="inline-flex items-center px-2 py-0.5 text-xs bg-white bg-opacity-70 rounded-full shadow-sm">
+              <Hash className="w-2.5 h-2.5 mr-0.5 flex-shrink-0" />
+              <span className="max-w-[60px] truncate">{tag}</span>
+            </span>
+          ))}
+          {note.tags.length > 3 && (
+            <span className="text-xs text-gray-500">+{note.tags.length - 3}</span>
+          )}
+        </div>
+      )}
+
+      <div className={`text-xs ${colorScheme.text} opacity-50`}>
+        {formatDate(note.updatedAt || note.createdAt)}
+      </div>
+    </div>
+  );
+});
+
+// 챕터 제목 포맷팅 유틸리티 함수 (컴포넌트 외부에 정의)
+const formatChapterTitle = (title) => {
+  if (!title) return '제목 없음';
+  let formatted = title;
+  if (formatted.length > 20) {
+    formatted = formatted.substring(0, 17) + '...';
+  }
+  return formatted
+    .replace(/[<>:"/\\|?*]/g, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+};
+
+// 노트 패널 컴포넌트 - 메모이제이션 최적화
+const NotePanel = ({ 
+  isVisible, 
+  onToggle, 
+  notes: externalNotes = [], 
+  selectedText = '', 
+  currentPage = 1, 
+  shouldOpenEditor = false, 
+  onEditorOpened, 
+  onNoteSave, 
+  tableOfContents = [] 
+}) => {
+  const [notes, setNotes] = useState([]);
+  const [editingNote, setEditingNote] = useState(null);
+  const [isCreating, setIsCreating] = useState(false);
+  const [searchTerm, setSearchTerm] = useState('');
+  const [filterType, setFilterType] = useState('all');
+  const [sortBy, setSortBy] = useState('date');
+
+  // 목차 데이터 변경 감지 (한 번만 로그)
+  useEffect(() => {
+    if (tableOfContents && tableOfContents.length > 0) {
+      console.log('🎯 NotePanel 목차 데이터 업데이트:', {
+        length: tableOfContents.length,
+        firstChapter: tableOfContents[0]?.title,
+        timestamp: new Date().toISOString()
+      });
+    }
+  }, [tableOfContents]);
+
+  // 챕터 정보 캐시 생성 - useMemo로 메모이제이션
+  const chapterCache = useMemo(() => {
+    console.log('🔄 챕터 캐시 생성 중...');
+    if (!tableOfContents || !Array.isArray(tableOfContents) || tableOfContents.length === 0) {
+      console.log('⚠️ 목차 데이터 없음, 캐시 생성 불가');
+      return new Map();
+    }
+
+    const cache = new Map();
+    const chapters = tableOfContents.filter(item => item.level === 0 || item.level === undefined);
+    console.log('📚 캐시 생성용 챕터:', chapters.length, '개');
+
+    // 각 챕터의 페이지 범위를 미리 계산
+    for (let i = 0; i < chapters.length; i++) {
+      const item = chapters[i];
+      if (!item.page || typeof item.page !== 'number') continue;
+
+      // 다음 챕터의 시작 페이지 찾기
+      let nextChapterPage = Number.MAX_SAFE_INTEGER;
+      for (let j = i + 1; j < chapters.length; j++) {
+        if (chapters[j].page && typeof chapters[j].page === 'number') {
+          nextChapterPage = chapters[j].page;
+          break;
+        }
       }
-      onNoteSave?.(noteData);
-    };
 
-    const handleDeleteNote = (noteId) => {
-      setNotes(notes.filter(note => note.id !== noteId));
-    };
+      // 이 챕터의 모든 페이지를 캐시에 추가
+      const chapterTitle = formatChapterTitle(item.title);
+      for (let page = item.page; page < nextChapterPage && page < item.page + 100; page++) {
+        cache.set(page, `${chapterTitle}.P${page}`);
+      }
+    }
 
-    const handleEditNote = (note) => {
-      setEditingNote(note);
-      setIsCreating(false);
-    };
+    console.log('✅ 챕터 캐시 생성 완료:', cache.size, '페이지');
+    return cache;
+  }, [tableOfContents]);
 
-    const cancelEditing = () => {
+  // 최적화된 getChapterInfo 함수 - 캐시 사용
+  const getChapterInfo = useCallback((page) => {
+    // 캐시에서 먼저 확인
+    if (chapterCache.has(page)) {
+      return chapterCache.get(page);
+    }
+    // 캐시에 없으면 기본값 반환
+    console.log('⚠️ 캐시에서 페이지를 찾을 수 없음:', page);
+    return `P.${page}`;
+  }, [chapterCache]);
+
+  useEffect(() => {
+    setNotes(externalNotes);
+  }, [externalNotes]);
+
+  useEffect(() => {
+    if (shouldOpenEditor) {
+      setIsCreating(true);
+      onEditorOpened?.();
+    }
+  }, [shouldOpenEditor, onEditorOpened]);
+
+  const handleSaveNote = useCallback((noteData) => {
+    if (editingNote) {
+      const updatedNotes = notes.map(note => 
+        note.id === editingNote.id ? { ...note, ...noteData } : note
+      );
+      setNotes(updatedNotes);
       setEditingNote(null);
+    } else {
+      const newNote = { ...noteData, id: Date.now() };
+      setNotes([newNote, ...notes]);
       setIsCreating(false);
-    };
+    }
+    onNoteSave?.(noteData);
+  }, [editingNote, notes, onNoteSave]);
 
-    // 필터링된 노트
-    const filteredNotes = notes.filter(note => {
+  const handleDeleteNote = useCallback((noteId) => {
+    setNotes(notes.filter(note => note.id !== noteId));
+  }, [notes]);
+
+  const handleEditNote = useCallback((note) => {
+    setEditingNote(note);
+    setIsCreating(false);
+  }, []);
+
+  const cancelEditing = useCallback(() => {
+    setEditingNote(null);
+    setIsCreating(false);
+  }, []);
+
+  // 필터링된 노트 메모이제이션
+  const filteredNotes = useMemo(() => {
+    return notes.filter(note => {
       const matchesSearch = note.title.toLowerCase().includes(searchTerm.toLowerCase()) ||
                            note.content.toLowerCase().includes(searchTerm.toLowerCase());
       const matchesType = filterType === 'all' || note.type === filterType;
       return matchesSearch && matchesType;
     });
+  }, [notes, searchTerm, filterType]);
 
-    // 정렬된 노트
-    const sortedNotes = [...filteredNotes].sort((a, b) => {
+  // 정렬된 노트 메모이제이션
+  const sortedNotes = useMemo(() => {
+    return [...filteredNotes].sort((a, b) => {
       if (sortBy === 'date') {
         return new Date(b.updatedAt || b.createdAt) - new Date(a.updatedAt || a.createdAt);
       }
@@ -322,119 +439,132 @@ const NoteEditor = ({ note, onSave, onCancel, isNew = false, currentPage = 1, se
       }
       return a.title.localeCompare(b.title);
     });
+  }, [filteredNotes, sortBy]);
 
-    return (
-      <div className="h-full flex flex-col bg-white">
-        {/* 헤더 */}
-        <div className="bg-gradient-to-r from-blue-50 to-indigo-50 border-b border-gray-100 p-4 flex-shrink-0">
-          <div className="flex items-center justify-between mb-4">
-            <h2 className="text-lg font-bold text-gray-900 flex items-center space-x-2">
-              <NotebookPen className="w-5 h-5" />
-              <span>노트</span>
-              <span className="text-sm text-gray-500 bg-blue-100 text-blue-600 px-2 py-0.5 rounded-full">
-                {notes.length}
-              </span>
-            </h2>
-            <button
-              onClick={onToggle}
-              className="p-2 text-gray-400 hover:text-gray-600 hover:bg-gray-100 rounded-lg transition-colors"
-            >
-              <X className="w-4 h-4" />
-            </button>
-          </div>
-          
-          {/* 검색 및 필터 */}
-          <div className="space-y-3">
-            <div className="relative">
-              <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 w-4 h-4 text-gray-400" />
-              <input
-                type="text"
-                placeholder="노트 검색..."
-                value={searchTerm}
-                onChange={(e) => setSearchTerm(e.target.value)}
-                className="w-full pl-10 pr-4 py-2 text-sm border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-              />
-            </div>
-            <div className="flex space-x-2">
-              <select
-                value={filterType}
-                onChange={(e) => setFilterType(e.target.value)}
-                className="flex-1 text-sm border border-gray-300 rounded-lg px-3 py-2 focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-              >
-                <option value="all">전체</option>
-                <option value="note">노트</option>
-                <option value="concept">개념</option>
-                <option value="question">질문</option>
-                <option value="important">중요</option>
-              </select>
-              <select
-                value={sortBy}
-                onChange={(e) => setSortBy(e.target.value)}
-                className="flex-1 text-sm border border-gray-300 rounded-lg px-3 py-2 focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-              >
-                <option value="date">최신순</option>
-                <option value="page">페이지순</option>
-                <option value="title">제목순</option>
-              </select>
-            </div>
-          </div>
+  return (
+    <div className="h-full flex flex-col bg-white">
+      {/* 헤더 */}
+      <div className="bg-gradient-to-r from-blue-50 to-indigo-50 border-b border-gray-100 p-3 sm:p-4 flex-shrink-0">
+        <div className="flex items-center justify-between mb-3 sm:mb-4">
+          <h2 className="text-base sm:text-lg font-bold text-gray-900 flex items-center space-x-2">
+            <NotebookPen className="w-4 sm:w-5 h-4 sm:h-5 text-blue-600 flex-shrink-0" />
+            <span className="truncate">노트</span>
+            <span className="text-xs sm:text-sm text-blue-600 bg-blue-100 px-2 py-0.5 rounded-full flex-shrink-0">
+              {notes.length}
+            </span>
+          </h2>
+          <button
+            onClick={onToggle}
+            className="p-2 text-gray-400 hover:text-gray-600 hover:bg-gray-100 rounded-lg transition-colors flex-shrink-0"
+          >
+            <X className="w-4 h-4" />
+          </button>
         </div>
 
-        {/* 노트 목록 */}
-        <div className="flex-1 overflow-auto p-4">
-          {editingNote && (
-            <NoteEditor
-              note={editingNote}
-              onSave={handleSaveNote}
-              onCancel={cancelEditing}
-              currentPage={currentPage}
-              selectedText={selectedText}
+        {/* 검색 및 필터 */}
+        <div className="space-y-3">
+          <div className="relative">
+            <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 w-4 h-4 text-gray-400" />
+            <input
+              type="text"
+              placeholder="노트 검색..."
+              value={searchTerm}
+              onChange={(e) => setSearchTerm(e.target.value)}
+              className="w-full pl-10 pr-4 py-2 text-sm border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent shadow-sm"
             />
-          )}
+          </div>
           
-          {isCreating && (
-            <NoteEditor
-              onSave={handleSaveNote}
-              onCancel={cancelEditing}
-              isNew={true}
-              currentPage={currentPage}
-              selectedText={selectedText}
-            />
-          )}
-          
-          {!editingNote && !isCreating && (
-            <>
-              <button
-                onClick={() => setIsCreating(true)}
-                className="w-full mb-4 p-4 border-2 border-dashed border-gray-300 rounded-xl hover:border-blue-400 hover:bg-blue-50 transition-colors flex items-center justify-center space-x-2"
-              >
-                <Plus className="w-5 h-5 text-gray-400" />
-                <span className="text-gray-600 font-medium">새 노트 작성</span>
-              </button>
-              
-              <div className="space-y-3">
-                {sortedNotes.length === 0 ? (
-                  <div className="text-center py-8 text-gray-500">
-                    <NotebookPen className="w-12 h-12 mx-auto mb-3 text-gray-300" />
-                    <p className="text-sm">아직 노트가 없습니다</p>
-                    <p className="text-xs text-gray-400 mt-1">텍스트를 선택하고 노트를 작성해보세요</p>
-                  </div>
-                ) : (
-                  sortedNotes.map(note => (
-                    <NoteCard
-                      key={note.id}
-                      note={note}
-                      onEdit={handleEditNote}
-                      onDelete={handleDeleteNote}
-                    />
-                  ))
-                )}
-              </div>
-            </>
-          )}
+          <div className="flex space-x-2">
+            <select
+              value={filterType}
+              onChange={(e) => setFilterType(e.target.value)}
+              className="flex-1 text-xs sm:text-sm border border-gray-300 rounded-lg px-2 sm:px-3 py-2 focus:ring-2 focus:ring-blue-500 focus:border-transparent shadow-sm"
+            >
+              <option value="all">전체</option>
+              <option value="note">노트</option>
+              <option value="concept">개념</option>
+              <option value="question">질문</option>
+              <option value="important">중요</option>
+            </select>
+            <select
+              value={sortBy}
+              onChange={(e) => setSortBy(e.target.value)}
+              className="flex-1 text-xs sm:text-sm border border-gray-300 rounded-lg px-2 sm:px-3 py-2 focus:ring-2 focus:ring-blue-500 focus:border-transparent shadow-sm"
+            >
+              <option value="date">최신순</option>
+              <option value="page">페이지순</option>
+              <option value="title">제목순</option>
+            </select>
+          </div>
         </div>
       </div>
-    );
-  };
 
-export default NotePanel; 
+      {/* 노트 목록 */}
+      <div className="flex-1 overflow-auto p-3 sm:p-4">
+        {editingNote && (
+          <NoteEditor
+            note={editingNote}
+            onSave={handleSaveNote}
+            onCancel={cancelEditing}
+            currentPage={currentPage}
+            selectedText={selectedText}
+            getChapterInfo={getChapterInfo}
+          />
+        )}
+
+        {isCreating && (
+          <NoteEditor
+            onSave={handleSaveNote}
+            onCancel={cancelEditing}
+            isNew={true}
+            currentPage={currentPage}
+            selectedText={selectedText}
+            getChapterInfo={getChapterInfo}
+          />
+        )}
+
+        {!editingNote && !isCreating && (
+          <>
+            <button
+              onClick={() => setIsCreating(true)}
+              className="w-full mb-4 p-3 sm:p-4 border-2 border-dashed border-gray-300 rounded-xl hover:border-blue-400 hover:bg-blue-50 transition-colors flex items-center justify-center space-x-2 group"
+            >
+              <Plus className="w-4 sm:w-5 h-4 sm:h-5 text-gray-400 group-hover:text-blue-500 transition-colors flex-shrink-0" />
+              <span className="text-sm sm:text-base text-gray-600 group-hover:text-blue-600 font-medium transition-colors">
+                새 노트 작성
+              </span>
+            </button>
+
+            <div className="space-y-3">
+              {sortedNotes.length === 0 ? (
+                <div className="text-center py-8 text-gray-500">
+                  <NotebookPen className="w-12 h-12 mx-auto mb-3 text-gray-300" />
+                  <p className="text-sm font-medium">
+                    {searchTerm || filterType !== 'all' ? '검색 결과가 없습니다' : '아직 노트가 없습니다'}
+                  </p>
+                  <p className="text-xs text-gray-400 mt-1 px-4">
+                    {searchTerm || filterType !== 'all' 
+                      ? '다른 검색어나 필터를 시도해보세요' 
+                      : '텍스트를 선택하고 노트를 작성해보세요'}
+                  </p>
+                </div>
+              ) : (
+                sortedNotes.map(note => (
+                  <NoteCard
+                    key={note.id}
+                    note={note}
+                    onEdit={handleEditNote}
+                    onDelete={handleDeleteNote}
+                    getChapterInfo={getChapterInfo}
+                  />
+                ))
+              )}
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default NotePanel;

--- a/src/components/plan/AIPlanGenerator.js
+++ b/src/components/plan/AIPlanGenerator.js
@@ -12,7 +12,7 @@ export default function AIPlanGenerator({ studyIntensity, onGenerate, planTasks,
     const newTask = {
       week: planTasks.length + 1,
       task: '',
-      date: '',
+      date: getDateForWeek(planTasks.length + 1), // 날짜 자동 생성
       done: false,
       memo: ''
     };
@@ -24,30 +24,38 @@ export default function AIPlanGenerator({ studyIntensity, onGenerate, planTasks,
     setPlanTasks(prev => prev.filter((_, i) => i !== idx));
   };
 
+  // 주차별 날짜 계산 함수
+  const getDateForWeek = (week) => {
+    const start = new Date();
+    start.setDate(start.getDate() + (week - 1) * 7);
+    return start.toISOString().split('T')[0];
+  };
+
   // 학습 강도별 추천 플랜 템플릿
   const getRecommendedPlan = () => {
     const templates = {
       '낮음': [
-        { week: 1, task: '1~2장 읽기 및 핵심 개념 정리', date: '', done: false, memo: '천천히 이해하며 읽기' },
-        { week: 2, task: '3~4장 읽기 및 예제 풀이', date: '', done: false, memo: '실습 위주로 학습' },
-        { week: 3, task: '5~6장 읽기 및 복습', date: '', done: false, memo: '이전 내용과 연결' },
+        { week: 1, task: '1~2장 읽기 및 핵심 개념 정리', date: getDateForWeek(1), done: false, memo: '천천히 이해하며 읽기' },
+        { week: 2, task: '3~4장 읽기 및 예제 풀이', date: getDateForWeek(2), done: false, memo: '실습 위주로 학습' },
+        { week: 3, task: '5~6장 읽기 및 복습', date: getDateForWeek(3), done: false, memo: '이전 내용과 연결' },
       ],
       '보통': [
-        { week: 1, task: '1~3장 읽기 및 개념 정리', date: '', done: false, memo: '기초 개념 확립' },
-        { week: 2, task: '4~6장 읽기 및 문제풀이', date: '', done: false, memo: '실습과 이론 병행' },
-        { week: 3, task: '7~9장 읽기 및 복습', date: '', done: false, memo: '전체적인 흐름 파악' },
-        { week: 4, task: '10~12장 읽기 및 심화 학습', date: '', done: false, memo: '심화 개념 도전' },
+        { week: 1, task: '1~3장 읽기 및 개념 정리', date: getDateForWeek(1), done: false, memo: '기초 개념 확립' },
+        { week: 2, task: '4~6장 읽기 및 문제풀이', date: getDateForWeek(2), done: false, memo: '실습과 이론 병행' },
+        { week: 3, task: '7~9장 읽기 및 복습', date: getDateForWeek(3), done: false, memo: '전체적인 흐름 파악' },
+        { week: 4, task: '10~12장 읽기 및 심화 학습', date: getDateForWeek(4), done: false, memo: '심화 개념 도전' },
       ],
       '높음': [
-        { week: 1, task: '1~5장 읽기 및 개념 정리', date: '', done: false, memo: '빠른 진도로 기초 확립' },
-        { week: 2, task: '6~10장 읽기 및 문제풀이', date: '', done: false, memo: '실습과 이론 병행' },
-        { week: 3, task: '11~15장 읽기 및 심화 학습', date: '', done: false, memo: '고급 개념 도전' },
-        { week: 4, task: '16~20장 읽기 및 종합 복습', date: '', done: false, memo: '전체 내용 통합' },
-        { week: 5, task: '21~25장 읽기 및 실전 연습', date: '', done: false, memo: '실전 문제 풀이' },
+        { week: 1, task: '1~5장 읽기 및 개념 정리', date: getDateForWeek(1), done: false, memo: '빠른 진도로 기초 확립' },
+        { week: 2, task: '6~10장 읽기 및 문제풀이', date: getDateForWeek(2), done: false, memo: '실습과 이론 병행' },
+        { week: 3, task: '11~15장 읽기 및 심화 학습', date: getDateForWeek(3), done: false, memo: '고급 개념 도전' },
+        { week: 4, task: '16~20장 읽기 및 종합 복습', date: getDateForWeek(4), done: false, memo: '전체 내용 통합' },
+        { week: 5, task: '21~25장 읽기 및 실전 연습', date: getDateForWeek(5), done: false, memo: '실전 문제 풀이' },
       ],
     };
     return templates[studyIntensity] || templates['보통'];
   };
+
 
   return (
     <div className="flex flex-col gap-4">

--- a/src/components/plan/WeeklyGoalsWidget.js
+++ b/src/components/plan/WeeklyGoalsWidget.js
@@ -1,0 +1,524 @@
+import React, { useState } from 'react';
+import { Target, Plus, X, Settings, CheckCircle, Calendar, Clock } from 'lucide-react';
+
+// 모달 컴포넌트
+const WeeklyGoalsModal = ({ 
+  isOpen, 
+  onClose, 
+  studyPlans = [], 
+  onPlansUpdate,
+  currentWeek 
+}) => {
+  const [newPlan, setNewPlan] = useState({ 
+    chapter: '', 
+    pages: '', 
+    week: `${currentWeek}주차`, 
+    date: '', 
+    days: [] 
+  });
+  const [showAddForm, setShowAddForm] = useState(false);
+
+  const dayNames = ['일', '월', '화', '수', '목', '금', '토'];
+
+  React.useEffect(() => {
+    if (isOpen) {
+      setNewPlan({ 
+        chapter: '', 
+        pages: '', 
+        week: `${currentWeek}주차`, 
+        date: '', 
+        days: [] 
+      });
+      setShowAddForm(false);
+    }
+  }, [isOpen, currentWeek]);
+
+  const handleAddPlan = () => {
+    if (!newPlan.chapter.trim()) return;
+    
+    const plan = {
+      id: Date.now().toString(),
+      chapter: newPlan.chapter,
+      pages: newPlan.pages,
+      week: newPlan.week,
+      date: newPlan.date || new Date().toISOString().split('T')[0],
+      days: newPlan.days,
+      completed: false,
+      createdAt: new Date().toISOString()
+    };
+    
+    onPlansUpdate([...studyPlans, plan]);
+    setNewPlan({ 
+      chapter: '', 
+      pages: '', 
+      week: `${currentWeek}주차`, 
+      date: '', 
+      days: [] 
+    });
+    setShowAddForm(false);
+  };
+
+  const handleRemovePlan = (planId) => {
+    onPlansUpdate(studyPlans.filter(plan => plan.id !== planId));
+  };
+  
+  const handleToggleDay = (dayIndex) => {
+    setNewPlan(prev => ({
+      ...prev,
+      days: prev.days.includes(dayIndex) 
+        ? prev.days.filter(d => d !== dayIndex)
+        : [...prev.days, dayIndex]
+    }));
+  };
+
+  const handleTogglePlanDay = (planId, dayIndex) => {
+    onPlansUpdate(studyPlans.map(plan => {
+      if (plan.id === planId) {
+        const days = plan.days || [];
+        const newDays = days.includes(dayIndex) 
+          ? days.filter(d => d !== dayIndex)
+          : [...days, dayIndex];
+        return { ...plan, days: newDays };
+      }
+      return plan;
+    }));
+  };
+
+  if (!isOpen) return null;
+
+  // 주차별로 그룹화
+  const plansByWeek = studyPlans.reduce((acc, plan) => {
+    const week = plan.week || '1주차';
+    if (!acc[week]) acc[week] = [];
+    acc[week].push(plan);
+    return acc;
+  }, {});
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
+      <div className="bg-white rounded-xl shadow-2xl max-w-4xl w-full max-h-[90vh] overflow-y-auto">
+        <div className="sticky top-0 bg-white border-b border-gray-200 px-6 py-4 rounded-t-xl">
+          <div className="flex items-center justify-between">
+            <h2 className="text-xl font-semibold text-gray-900">주간 학습 계획 관리</h2>
+            <button
+              onClick={onClose}
+              className="p-2 text-gray-500 hover:text-gray-700 hover:bg-gray-100 rounded-lg transition-colors"
+            >
+              <X className="w-5 h-5" />
+            </button>
+          </div>
+        </div>
+        
+        <div className="p-6">
+          {/* 계획 추가 버튼 */}
+          <div className="flex justify-between items-center mb-6">
+            <h3 className="text-lg font-medium text-gray-900">학습 계획 목록</h3>
+            <button
+              onClick={() => setShowAddForm(true)}
+              className="px-4 py-2 bg-amber-600 text-white rounded-lg hover:bg-amber-700 transition-colors flex items-center gap-2"
+            >
+              <Plus className="w-4 h-4" />
+              계획 추가
+            </button>
+          </div>
+
+          {/* 계획 추가 폼 */}
+          {showAddForm && (
+            <div className="bg-amber-50 rounded-lg p-4 mb-6 border border-amber-200">
+              <div className="space-y-4">
+                <div>
+                  <label className="block text-sm font-medium text-amber-700 mb-1">학습 내용</label>
+                  <input
+                    type="text"
+                    value={newPlan.chapter}
+                    onChange={(e) => setNewPlan(prev => ({ ...prev, chapter: e.target.value }))}
+                    className="w-full border border-amber-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-amber-500"
+                    placeholder="예: Chapter 1-3 완독"
+                  />
+                </div>
+                <div>
+                  <label className="block text-sm font-medium text-amber-700 mb-1">페이지 범위 (선택)</label>
+                  <input
+                    type="text"
+                    value={newPlan.pages}
+                    onChange={(e) => setNewPlan(prev => ({ ...prev, pages: e.target.value }))}
+                    className="w-full border border-amber-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-amber-500"
+                    placeholder="예: 1-50p"
+                  />
+                </div>
+                <div>
+                  <label className="block text-sm font-medium text-amber-700 mb-1">주차</label>
+                  <select
+                    value={newPlan.week}
+                    onChange={(e) => setNewPlan(prev => ({ ...prev, week: e.target.value }))}
+                    className="w-full border border-amber-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-amber-500"
+                  >
+                    {[1, 2, 3, 4, 5, 6, 7, 8].map(week => (
+                      <option key={week} value={`${week}주차`}>{week}주차</option>
+                    ))}
+                  </select>
+                </div>
+                <div>
+                  <label className="block text-sm font-medium text-amber-700 mb-2">학습 예정일</label>
+                  <div className="grid grid-cols-7 gap-2">
+                    {dayNames.map((day, index) => (
+                      <button
+                        key={index}
+                        type="button"
+                        onClick={() => handleToggleDay(index)}
+                        className={`
+                          p-2 rounded-lg text-sm font-medium transition-all duration-200
+                          ${newPlan.days.includes(index)
+                            ? 'bg-amber-500 text-white shadow-sm' 
+                            : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
+                          }
+                        `}
+                      >
+                        {day}
+                      </button>
+                    ))}
+                  </div>
+                </div>
+                <div className="flex gap-2">
+                  <button
+                    onClick={handleAddPlan}
+                    className="px-4 py-2 bg-amber-600 text-white rounded-lg hover:bg-amber-700 transition-colors"
+                  >
+                    추가
+                  </button>
+                  <button
+                    onClick={() => setShowAddForm(false)}
+                    className="px-4 py-2 bg-gray-200 text-gray-700 rounded-lg hover:bg-gray-300 transition-colors"
+                  >
+                    취소
+                  </button>
+                </div>
+              </div>
+            </div>
+          )}
+
+          {/* 주차별 계획 목록 */}
+          <div className="space-y-6">
+            {Object.entries(plansByWeek).sort().map(([week, weekPlans]) => (
+              <div key={week} className="border border-gray-200 rounded-lg p-4">
+                <h4 className="text-lg font-medium text-gray-900 mb-4">{week}</h4>
+                <div className="space-y-4">
+                  {weekPlans.map((plan) => (
+                    <div
+                      key={plan.id}
+                      className={`p-4 rounded-lg border transition-colors ${
+                        plan.completed
+                          ? 'bg-green-50 border-green-200'
+                          : 'bg-white border-gray-200'
+                      }`}
+                    >
+                      <div className="flex items-center justify-between mb-4">
+                        <div className="flex-1">
+                          <div className={`font-semibold ${plan.completed ? 'text-green-700' : 'text-gray-900'}`}>
+                            {plan.chapter}
+                          </div>
+                          {plan.pages && (
+                            <div className={`text-sm ${plan.completed ? 'text-green-600' : 'text-gray-600'}`}>
+                              {plan.pages}
+                            </div>
+                          )}
+                          {plan.date && (
+                            <div className={`text-xs ${plan.completed ? 'text-green-500' : 'text-gray-500'}`}>
+                              {plan.date}
+                            </div>
+                          )}
+                        </div>
+                        <div className="flex items-center gap-2">
+                          <button
+                            onClick={() => handleRemovePlan(plan.id)}
+                            className="p-1 text-gray-400 hover:text-red-500 transition-colors"
+                          >
+                            <X className="w-4 h-4" />
+                          </button>
+                        </div>
+                      </div>
+
+                      {/* 주간 일정 설정 */}
+                      <div>
+                        <p className="text-sm text-gray-700 mb-2">학습 예정일</p>
+                        <div className="grid grid-cols-7 gap-2">
+                          {dayNames.map((day, index) => {
+                            const isScheduled = (plan.days || []).includes(index);
+                            return (
+                              <button
+                                key={index}
+                                onClick={() => handleTogglePlanDay(plan.id, index)}
+                                className={`
+                                  p-2 rounded-lg text-sm font-medium transition-all duration-200
+                                  ${isScheduled 
+                                    ? 'bg-amber-500 text-white shadow-sm' 
+                                    : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
+                                  }
+                                `}
+                              >
+                                {day}
+                              </button>
+                            );
+                          })}
+                        </div>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            ))}
+          </div>
+
+          {studyPlans.length === 0 && (
+            <div className="text-center py-12 text-gray-500">
+              <Settings className="w-12 h-12 mx-auto mb-4 text-gray-400" />
+              <p className="text-lg mb-2">아직 설정된 학습 계획이 없습니다</p>
+              <p className="text-sm">계획 추가 버튼을 클릭하여 새로운 계획을 만들어보세요</p>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+// 주간 학습 목표 위젯 컴포넌트
+const WeeklyGoalsWidget = ({ 
+  studyPlans = [], 
+  onStudyPlansUpdate,
+  className = ""
+}) => {
+  const [showModal, setShowModal] = useState(false);
+  
+  // 현재 주차 계산 (기존 계획에서 가장 최근 주차를 찾거나 1주차 기본값)
+  const getCurrentWeek = () => {
+    if (studyPlans.length === 0) return 1;
+    
+    // 기존 계획에서 주차 정보 추출
+    const weeks = studyPlans
+      .filter(plan => plan.week)
+      .map(plan => parseInt(plan.week.replace('주차', '')))
+      .filter(week => !isNaN(week));
+    
+    return weeks.length > 0 ? Math.max(...weeks) : 1;
+  };
+  
+  const currentWeek = getCurrentWeek();
+  const currentWeekStr = `${currentWeek}주차`;
+  const dayNames = ['일', '월', '화', '수', '목', '금', '토'];
+  const today = new Date().getDay();
+
+  // 현재 주차에 해당하는 계획만 필터링
+  const currentWeekPlans = studyPlans.filter(plan => 
+    plan.week === currentWeekStr || 
+    (!plan.week && currentWeek === 1) // week 정보가 없는 기존 계획은 1주차로 간주
+  );
+  
+  const handleToggleCompleted = (planId) => {
+    const updatedPlans = studyPlans.map(plan => {
+      if (plan.id === planId) {
+        return { ...plan, completed: !plan.completed };
+      }
+      return plan;
+    });
+    onStudyPlansUpdate(updatedPlans);
+  };
+
+  // 완료된 계획 수 계산
+  const completedPlans = currentWeekPlans.filter(plan => plan.completed).length;
+  const totalPlans = currentWeekPlans.length;
+  const completionRate = totalPlans > 0 ? Math.round((completedPlans / totalPlans) * 100) : 0;
+
+  // 오늘 학습 예정인 계획들
+  const todayPlans = currentWeekPlans.filter(plan => 
+    (plan.days || []).includes(today) && !plan.completed
+  );
+
+  return (
+    <>
+      <div className={`group p-6 ${className}`}>
+        <div className="flex items-center justify-between mb-4">
+          <div className="flex items-center gap-2">
+            <div className="p-2 bg-amber-100 rounded-xl group-hover:bg-amber-200 transition-colors">
+              <Target className="w-5 h-5 text-amber-600" />
+            </div>
+            <h3 className="text-lg font-bold text-amber-900">주간 학습 목표</h3>
+          </div>
+          <div className="flex items-center gap-2">
+            <div className="px-3 py-1 bg-white/80 rounded-full text-sm font-bold text-amber-700">
+              {currentWeekStr}
+            </div>
+            <button
+              onClick={() => setShowModal(true)}
+              className="p-2 text-amber-600 hover:text-amber-800 hover:bg-white/60 rounded-lg transition-all duration-200"
+              title="학습 계획 관리"
+            >
+              <Settings className="w-4 h-4" />
+            </button>
+          </div>
+        </div>
+
+        <div className="space-y-4">
+          {currentWeekPlans.length === 0 ? (
+            <div className="bg-white/60 border-2 border-dashed border-amber-200 rounded-xl p-6 text-center">
+              <Calendar className="w-8 h-8 mx-auto mb-3 text-amber-400" />
+              <p className="text-sm font-medium text-amber-600 mb-2">이번 주에 설정된 학습 계획이 없습니다</p>
+              <button
+                onClick={() => setShowModal(true)}
+                className="text-xs text-amber-700 hover:text-amber-800 font-bold bg-white/80 hover:bg-white/90 px-3 py-2 rounded-lg transition-all duration-200"
+              >
+                + 계획 설정하기
+              </button>
+            </div>
+          ) : (
+            <>
+              {/* 현재 주차 계획들 */}
+              {currentWeekPlans.slice(0, 2).map((plan) => (
+                <div
+                  key={plan.id}
+                  className={`rounded-xl p-4 transition-all duration-200 ${
+                    plan.completed
+                      ? 'bg-emerald-100/80 border border-emerald-200'
+                      : 'bg-white/80 backdrop-blur-sm hover:bg-white/90 border border-white/50'
+                  }`}
+                >
+                  <div className="flex items-center justify-between mb-3">
+                    <div className="flex-1">
+                      <div className={`font-bold text-sm mb-1 ${plan.completed ? 'text-emerald-700' : 'text-amber-900'}`}>
+                        {plan.chapter}
+                      </div>
+                      {plan.pages && (
+                        <div className={`text-xs ${plan.completed ? 'text-emerald-600' : 'text-amber-700'}`}>
+                          {plan.pages}
+                        </div>
+                      )}
+                      {plan.date && (
+                        <div className={`text-xs ${plan.completed ? 'text-emerald-500' : 'text-amber-600'}`}>
+                          {plan.date}
+                        </div>
+                      )}
+                    </div>
+                    <button
+                      onClick={() => handleToggleCompleted(plan.id)}
+                      className={`w-8 h-8 rounded-full flex items-center justify-center transition-all duration-200 ${
+                        plan.completed
+                          ? 'bg-emerald-500 text-white shadow-md'
+                          : 'bg-white text-amber-600 border-2 border-amber-200 hover:border-amber-400 hover:shadow-sm'
+                      }`}
+                    >
+                      {plan.completed ? (
+                        <CheckCircle className="w-5 h-5" />
+                      ) : (
+                        <div className="w-3 h-3 rounded-full border border-current" />
+                      )}
+                    </button>
+                  </div>
+
+                  {/* 주간 학습 일정 표시 */}
+                  {plan.days && plan.days.length > 0 && (
+                    <div className="mt-3">
+                      <div className="text-xs text-amber-600 mb-2 font-medium flex items-center gap-1">
+                        <Clock className="w-3 h-3" />
+                        학습 예정일
+                      </div>
+                      <div className="grid grid-cols-7 gap-1">
+                        {dayNames.map((day, index) => {
+                          const isScheduled = plan.days.includes(index);
+                          const isToday = index === today;
+                          
+                          return (
+                            <div key={index} className="text-center">
+                              <div className="text-xs text-amber-600 mb-1 font-medium">{day}</div>
+                              <div
+                                className={`
+                                  w-6 h-6 mx-auto rounded-full flex items-center justify-center transition-all duration-200 text-xs
+                                  ${!isScheduled 
+                                    ? 'bg-white/50 text-amber-300' 
+                                    : plan.completed
+                                      ? 'bg-emerald-500 text-white shadow-sm'
+                                      : isToday
+                                        ? 'bg-amber-500 text-white shadow-md ring-2 ring-amber-300'
+                                        : 'bg-amber-200 text-amber-700'
+                                  }
+                                `}
+                              >
+                                {!isScheduled ? (
+                                  '·'
+                                ) : plan.completed ? (
+                                  <CheckCircle className="w-4 h-4" />
+                                ) : isToday ? (
+                                  '!'
+                                ) : (
+                                  '○'
+                                )}
+                              </div>
+                            </div>
+                          );
+                        })}
+                      </div>
+                    </div>
+                  )}
+                </div>
+              ))}
+
+              {/* 추가 계획이 있을 때 */}
+              {currentWeekPlans.length > 2 && (
+                <button
+                  onClick={() => setShowModal(true)}
+                  className="w-full py-3 text-sm font-semibold text-amber-700 hover:text-amber-800 bg-white/60 hover:bg-white/80 rounded-xl transition-all duration-200 border border-dashed border-amber-300"
+                >
+                  + {currentWeekPlans.length - 2}개 계획 더 보기
+                </button>
+              )}
+
+              {/* 오늘의 학습 목표 */}
+              {todayPlans.length > 0 && (
+                <div className="bg-amber-100/80 backdrop-blur-sm rounded-xl p-3 border border-amber-200">
+                  <div className="flex items-center gap-2 mb-2">
+                    <Calendar className="w-4 h-4 text-amber-600" />
+                    <span className="text-sm font-bold text-amber-800">오늘의 학습 목표</span>
+                  </div>
+                  <div className="space-y-1">
+                    {todayPlans.slice(0, 2).map(plan => (
+                      <div key={plan.id} className="flex items-center gap-2">
+                        <div className="w-2 h-2 bg-amber-500 rounded-full" />
+                        <span className="text-xs text-amber-700 font-medium">{plan.chapter}</span>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              )}
+
+              {/* 전체 주간 진행률 */}
+              <div className="bg-white/70 backdrop-blur-sm rounded-xl p-3">
+                <div className="flex items-center justify-between text-sm mb-2">
+                  <span className="text-amber-700 font-medium">이번 주 진행률</span>
+                  <span className="font-bold text-amber-800">
+                    {completedPlans} / {totalPlans} 개 완료 ({completionRate}%)
+                  </span>
+                </div>
+                <div className="w-full bg-amber-200 rounded-full h-2">
+                  <div
+                    className="bg-gradient-to-r from-amber-400 to-amber-500 h-2 rounded-full transition-all duration-700 shadow-sm"
+                    style={{ width: `${completionRate}%` }}
+                  />
+                </div>
+              </div>
+            </>
+          )}
+        </div>
+      </div>
+
+      {/* 모달 */}
+      <WeeklyGoalsModal
+        isOpen={showModal}
+        onClose={() => setShowModal(false)}
+        studyPlans={studyPlans}
+        onPlansUpdate={onStudyPlansUpdate}
+        currentWeek={currentWeek}
+      />
+    </>
+  );
+};
+
+export default WeeklyGoalsWidget;

--- a/src/components/textbook/MemoListPanel.js
+++ b/src/components/textbook/MemoListPanel.js
@@ -1,0 +1,287 @@
+import React, { useState, useMemo } from 'react';
+import { Search, Filter, StickyNote, MessageSquare, Calendar, ChevronDown, ChevronRight, X } from 'lucide-react';
+
+const MemoListPanel = ({ 
+  allNotes = [], 
+  pdfAnnotations = [], 
+  currentPage, 
+  onNoteClick, 
+  onAnnotationClick,
+  tableOfContents = []
+}) => {
+  const [searchTerm, setSearchTerm] = useState('');
+  const [filterType, setFilterType] = useState('all'); // all, notes, annotations
+  const [sortBy, setSortBy] = useState('recent'); // recent, page, alphabetical
+  const [showFilters, setShowFilters] = useState(false);
+
+  // 모든 메모 데이터 통합
+  const allMemos = useMemo(() => {
+    const notes = allNotes.map(note => ({
+      ...note,
+      type: 'note',
+      displayType: '노트',
+      icon: StickyNote,
+      color: note.color || 'blue'
+    }));
+
+    const annotations = pdfAnnotations.map(annotation => ({
+      ...annotation,
+      type: 'annotation',
+      displayType: 'PDF 메모',
+      icon: MessageSquare,
+      title: annotation.text,
+      content: annotation.memo,
+      color: annotation.colorName || 'yellow'
+    }));
+
+    return [...notes, ...annotations];
+  }, [allNotes, pdfAnnotations]);
+
+  // 필터링 및 정렬
+  const filteredAndSortedMemos = useMemo(() => {
+    let filtered = allMemos;
+
+    // 타입 필터
+    if (filterType !== 'all') {
+      filtered = filtered.filter(memo => memo.type === filterType);
+    }
+
+    // 검색 필터
+    if (searchTerm) {
+      filtered = filtered.filter(memo => 
+        memo.title?.toLowerCase().includes(searchTerm.toLowerCase()) ||
+        memo.content?.toLowerCase().includes(searchTerm.toLowerCase())
+      );
+    }
+
+    // 정렬
+    filtered.sort((a, b) => {
+      switch (sortBy) {
+        case 'page':
+          return (a.page || a.pageNumber || 0) - (b.page || b.pageNumber || 0);
+        case 'alphabetical':
+          return (a.title || '').localeCompare(b.title || '');
+        case 'recent':
+        default:
+          return new Date(b.createdAt || b.updatedAt || 0) - new Date(a.createdAt || a.updatedAt || 0);
+      }
+    });
+
+    return filtered;
+  }, [allMemos, searchTerm, filterType, sortBy]);
+
+  // 페이지별 그룹화
+  const memosByPage = useMemo(() => {
+    const grouped = {};
+    filteredAndSortedMemos.forEach(memo => {
+      const page = memo.page || memo.pageNumber || 1;
+      if (!grouped[page]) {
+        grouped[page] = [];
+      }
+      grouped[page].push(memo);
+    });
+    return grouped;
+  }, [filteredAndSortedMemos]);
+
+  // 챕터 정보 가져오기
+  const getChapterForPage = (page) => {
+    if (!tableOfContents || tableOfContents.length === 0) return null;
+    
+    for (let i = 0; i < tableOfContents.length; i++) {
+      const item = tableOfContents[i];
+      if (item.level === 0 && item.page && page >= item.page) {
+        const nextChapter = tableOfContents.find((next, idx) => 
+          idx > i && next.level === 0 && next.page
+        );
+        if (!nextChapter || page < nextChapter.page) {
+          return item.title;
+        }
+      }
+    }
+    return null;
+  };
+
+  const handleMemoClick = (memo) => {
+    if (memo.type === 'note' && onNoteClick) {
+      onNoteClick(memo);
+    } else if (memo.type === 'annotation' && onAnnotationClick) {
+      onAnnotationClick(memo);
+    }
+  };
+
+  const getColorClass = (color) => {
+    const colorMap = {
+      blue: 'bg-blue-100 text-blue-800 border-blue-200',
+      yellow: 'bg-yellow-100 text-yellow-800 border-yellow-200',
+      green: 'bg-green-100 text-green-800 border-green-200',
+      purple: 'bg-purple-100 text-purple-800 border-purple-200',
+      red: 'bg-red-100 text-red-800 border-red-200',
+      pink: 'bg-pink-100 text-pink-800 border-pink-200'
+    };
+    return colorMap[color] || colorMap.blue;
+  };
+
+  if (allMemos.length === 0) {
+    return (
+      <div className="h-full flex items-center justify-center p-6">
+        <div className="text-center">
+          <StickyNote className="w-12 h-12 text-gray-300 mx-auto mb-3" />
+          <p className="text-gray-500 text-sm">아직 작성된 메모가 없습니다</p>
+          <p className="text-gray-400 text-xs mt-1">텍스트를 선택하여 메모를 추가해보세요</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="h-full flex flex-col bg-white">
+      {/* 헤더 */}
+      <div className="p-4 border-b border-gray-100">
+        <div className="flex items-center justify-between mb-3">
+          <h3 className="text-lg font-semibold text-gray-900">메모 목록</h3>
+          <div className="flex items-center space-x-1">
+            <span className="text-xs text-gray-500 bg-gray-100 px-2 py-1 rounded-full">
+              {filteredAndSortedMemos.length}개
+            </span>
+            <button
+              onClick={() => setShowFilters(!showFilters)}
+              className="p-1.5 text-gray-400 hover:text-gray-600 rounded-lg hover:bg-gray-100"
+            >
+              <Filter className="w-4 h-4" />
+            </button>
+          </div>
+        </div>
+
+        {/* 검색 */}
+        <div className="relative">
+          <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 w-4 h-4 text-gray-400" />
+          <input
+            type="text"
+            placeholder="메모 검색..."
+            value={searchTerm}
+            onChange={(e) => setSearchTerm(e.target.value)}
+            className="w-full pl-10 pr-4 py-2 text-sm border border-gray-200 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+          />
+        </div>
+
+        {/* 필터 옵션 */}
+        {showFilters && (
+          <div className="mt-3 p-3 bg-gray-50 rounded-lg space-y-3">
+            <div>
+              <label className="text-xs font-medium text-gray-700 mb-2 block">타입</label>
+              <div className="flex space-x-2">
+                {[
+                  { value: 'all', label: '전체' },
+                  { value: 'note', label: '노트' },
+                  { value: 'annotation', label: 'PDF 메모' }
+                ].map(option => (
+                  <button
+                    key={option.value}
+                    onClick={() => setFilterType(option.value)}
+                    className={`px-3 py-1 text-xs rounded-full transition-colors ${
+                      filterType === option.value
+                        ? 'bg-blue-600 text-white'
+                        : 'bg-white text-gray-600 hover:bg-gray-100'
+                    }`}
+                  >
+                    {option.label}
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            <div>
+              <label className="text-xs font-medium text-gray-700 mb-2 block">정렬</label>
+              <div className="flex space-x-2">
+                {[
+                  { value: 'recent', label: '최신순' },
+                  { value: 'page', label: '페이지순' },
+                  { value: 'alphabetical', label: '가나다순' }
+                ].map(option => (
+                  <button
+                    key={option.value}
+                    onClick={() => setSortBy(option.value)}
+                    className={`px-3 py-1 text-xs rounded-full transition-colors ${
+                      sortBy === option.value
+                        ? 'bg-blue-600 text-white'
+                        : 'bg-white text-gray-600 hover:bg-gray-100'
+                    }`}
+                  >
+                    {option.label}
+                  </button>
+                ))}
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* 메모 목록 */}
+      <div className="flex-1 overflow-y-auto">
+        {Object.keys(memosByPage).length === 0 ? (
+          <div className="p-6 text-center">
+            <p className="text-gray-500 text-sm">검색 결과가 없습니다</p>
+          </div>
+        ) : (
+          <div className="p-4 space-y-4">
+            {Object.entries(memosByPage)
+              .sort(([a], [b]) => parseInt(a) - parseInt(b))
+              .map(([page, memos]) => (
+                <div key={page} className="space-y-2">
+                  {/* 페이지 헤더 */}
+                  <div className="flex items-center space-x-2 mb-3">
+                    <div className={`px-2 py-1 rounded-lg text-xs font-medium ${
+                      parseInt(page) === currentPage 
+                        ? 'bg-blue-100 text-blue-700' 
+                        : 'bg-gray-100 text-gray-600'
+                    }`}>
+                      P.{page}
+                    </div>
+                    {getChapterForPage(parseInt(page)) && (
+                      <div className="text-xs text-gray-500 truncate">
+                        {getChapterForPage(parseInt(page))}
+                      </div>
+                    )}
+                  </div>
+
+                  {/* 메모들 */}
+                  {memos.map((memo) => {
+                    const IconComponent = memo.icon;
+                    return (
+                      <div
+                        key={memo.id}
+                        onClick={() => handleMemoClick(memo)}
+                        className={`p-3 rounded-lg border cursor-pointer transition-all hover:shadow-sm ${getColorClass(memo.color)}`}
+                      >
+                        <div className="flex items-start space-x-2">
+                          <IconComponent className="w-4 h-4 mt-0.5 flex-shrink-0" />
+                          <div className="flex-1 min-w-0">
+                            <div className="flex items-center justify-between mb-1">
+                              <span className="text-xs font-medium opacity-75">
+                                {memo.displayType}
+                              </span>
+                              <span className="text-xs opacity-60">
+                                {memo.createdAt ? new Date(memo.createdAt).toLocaleDateString() : ''}
+                              </span>
+                            </div>
+                            <h4 className="text-sm font-medium mb-1 line-clamp-1">
+                              {memo.title || '제목 없음'}
+                            </h4>
+                            <p className="text-xs opacity-75 line-clamp-2">
+                              {memo.content || memo.memo || '내용 없음'}
+                            </p>
+                          </div>
+                        </div>
+                      </div>
+                    );
+                  })}
+                </div>
+              ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default MemoListPanel;

--- a/src/index.css
+++ b/src/index.css
@@ -1,6 +1,4 @@
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
+@import "tailwindcss";
 
 /* react-pdf AnnotationLayer 스타일 */
 .react-pdf__Page__annotations {

--- a/src/pages/Dashboard/index.js
+++ b/src/pages/Dashboard/index.js
@@ -1,32 +1,35 @@
 import React, { useState, useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
-import { Clock, Target, CheckCircle, Bell, BookOpen, TrendingUp, Flame, Calendar, Plus, Zap, Brain, Timer, BarChart3, BookMarked, CheckCircle2, Play, Pause, RotateCcw, Sparkles, Sun, Moon, Sunrise } from 'lucide-react';
+import { Clock, Target, CheckCircle, Bell, BookOpen, TrendingUp, Flame, Calendar, Plus, Zap, Brain, Timer, BarChart3, BookMarked, CheckCircle2, Play, Pause, RotateCcw, Sparkles, Sun, Moon, Sunrise, Settings, User, LogOut, MoreHorizontal } from 'lucide-react';
 import { XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, AreaChart, Area } from 'recharts';
-import Button from '../../components/common/Button';
-import Modal from '../../components/common/Modal';
-import Toast from '../../components/common/Toast';
-import { useProjectContext } from '../../context/ProjectContext';
-import { useStudyContext } from '../../context/StudyContext';
 
 const Dashboard = () => {
-  const navigate = useNavigate();
-  const { projects } = useProjectContext();
-  const { 
-    subjects, 
-    textbooks,
-    studyLogs,
-    goals,
-    getTotalStudyTime, 
-    getCompletionRate, 
-    getCurrentStreak, 
-    getWeeklyStudyData,
-  } = useStudyContext();
+  // Mock data - 실제로는 context에서 가져올 데이터
+  const subjects = [
+    { id: 1, name: '알고리즘', completedChapters: 8, totalChapters: 12, priority: 'high', color: '#3b82f6' },
+    { id: 2, name: '데이터베이스', completedChapters: 6, totalChapters: 10, priority: 'medium', color: '#10b981' },
+    { id: 3, name: '운영체제', completedChapters: 4, totalChapters: 8, priority: 'medium', color: '#f59e0b' }
+  ];
+
+  const projects = [
+    { id: 1, name: '캡스톤 프로젝트', description: 'AI 기반 학습 관리 시스템', progress: 75, status: 'in-progress', priority: 'high', icon: '🚀' },
+    { id: 2, name: '웹 포트폴리오', description: '개인 포트폴리오 웹사이트 제작', progress: 45, status: 'in-progress', priority: 'medium', icon: '💼' }
+  ];
+
+  const textbooks = [
+    { id: 1, title: 'Clean Code', author: 'Robert Martin', currentPage: 120, totalPages: 400, priority: 'high' },
+    { id: 2, title: 'System Design Interview', author: 'Alex Xu', currentPage: 80, totalPages: 300, priority: 'medium' }
+  ];
+
+  const studyLogs = [];
+  const goals = [
+    { id: 1, title: '알고리즘 마스터', progress: 80 },
+    { id: 2, title: '프로젝트 완성', progress: 75 }
+  ];
 
   // 실제 데이터에서 Todo 목록 생성
   const [todoList, setTodoList] = useState([]);
   
   useEffect(() => {
-    // 학습 과목과 프로젝트에서 할 일 생성
     const todos = [
       ...subjects.map(subject => ({
         id: `subject-${subject.id}`,
@@ -53,17 +56,20 @@ const Dashboard = () => {
       }))
     ];
     setTodoList(todos);
-  }, [subjects, projects, textbooks]);
+  }, []);
 
   // 모달 상태
   const [showAddTodoModal, setShowAddTodoModal] = useState(false);
-  const [showQuickAddModal, setShowQuickAddModal] = useState(false);
   const [newTodo, setNewTodo] = useState({ text: '', priority: 'medium' });
 
   // 토스트 상태
   const [showToast, setShowToast] = useState(false);
   const [toastMessage, setToastMessage] = useState('');
   const [toastType, setToastType] = useState('success');
+
+  // 알림 드롭다운 상태
+  const [showNotifications, setShowNotifications] = useState(false);
+  const [showUserMenu, setShowUserMenu] = useState(false);
 
   // 시간 기반 인사말
   const getTimeBasedGreeting = () => {
@@ -77,7 +83,6 @@ const Dashboard = () => {
   // 현재 시간 상태
   const [currentTime, setCurrentTime] = useState(new Date());
   const [studyTimer, setStudyTimer] = useState({ isActive: false, seconds: 0, subject: null });
-  const [showNotifications, setShowNotifications] = useState(false);
 
   // 시간 업데이트
   useEffect(() => {
@@ -95,6 +100,20 @@ const Dashboard = () => {
     }
     return () => clearInterval(interval);
   }, [studyTimer.isActive]);
+
+  // Mock functions
+  const getTotalStudyTime = () => 7200; // 2시간 in seconds
+  const getCompletionRate = () => 78;
+  const getCurrentStreak = () => 12;
+  const getWeeklyStudyData = () => [
+    { day: '월', hours: 3 },
+    { day: '화', hours: 2.5 },
+    { day: '수', hours: 4 },
+    { day: '목', hours: 2 },
+    { day: '금', hours: 3.5 },
+    { day: '토', hours: 1.5 },
+    { day: '일', hours: 2 }
+  ];
 
   // 유틸리티 함수들
   const formatTime = (seconds) => {
@@ -130,45 +149,6 @@ const Dashboard = () => {
     completedGoals: goals.filter(goal => goal.progress >= 100).length
   };
 
-  // 학습 과목 데이터
-  const studySubjects = subjects.map(subject => ({
-    id: `study-${subject.id}`,
-    name: subject.name,
-    description: `${subject.completedChapters}/${subject.totalChapters} 챕터 완료`,
-    progress: Math.round((subject.completedChapters / subject.totalChapters) * 100),
-    status: subject.completedChapters === subject.totalChapters ? 'completed' : 'in-progress',
-    priority: subject.priority,
-    color: subject.color,
-    icon: '📚',
-    type: 'study'
-  }));
-
-  // 프로젝트 데이터
-  const currentProjects = projects.map(project => ({
-    id: `project-${project.id}`,
-    name: project.name,
-    description: project.description,
-    progress: project.progress || 0,
-    status: project.status,
-    priority: project.priority,
-    color: project.color,
-    icon: project.icon,
-    type: 'project'
-  }));
-
-  // 학습 데이터
-  const weeklyStudyData = getWeeklyStudyData();
-
-  // 과목별 성과 데이터
-  const subjectPerformance = subjects.map(subject => ({
-    name: subject.name,
-    progress: Math.round((subject.completedChapters / subject.totalChapters) * 100),
-    studyTime: studyLogs
-      .filter(log => log.subjectId === subject.id)
-      .reduce((total, log) => total + log.duration, 0) / 60,
-    color: subject.color || '#3b82f6'
-  }));
-
   // 알림 데이터
   const notifications = [
     ...subjects.filter(subject => subject.completedChapters < subject.totalChapters)
@@ -190,25 +170,21 @@ const Dashboard = () => {
         priority: project.priority,
         time: '1시간 전',
         urgent: project.priority === 'high'
-      })),
-    ...textbooks.filter(textbook => textbook.currentPage < textbook.totalPages)
-      .map(textbook => ({
-        id: `textbook-${textbook.id}`,
-        title: `${textbook.title} 독서 필요`,
-        message: `${textbook.currentPage + 1}페이지를 읽어주세요`,
-        type: 'textbook',
-        priority: textbook.priority,
-        time: '2시간 전',
-        urgent: textbook.priority === 'high'
       }))
   ];
 
-  // 오늘의 추천 학습 (AI 기반)
+  // 마감일 데이터
+  const upcomingDeadlines = [
+    { id: 1, title: '알고리즘 과목 완료', dueDate: '2024-12-30', priority: 'high', type: 'study' },
+    { id: 2, title: '캡스톤 프로젝트 제출', dueDate: '2024-12-25', priority: 'high', type: 'project' },
+    { id: 3, title: 'Clean Code 완독', dueDate: '2024-12-20', priority: 'medium', type: 'textbook' }
+  ].sort((a, b) => new Date(a.dueDate) - new Date(b.dueDate));
+
+  // 오늘의 추천 학습
   const getTodayRecommendations = () => {
     const currentHour = currentTime.getHours();
     const recommendations = [];
 
-    // 아침 추천 (6-12시)
     if (currentHour >= 6 && currentHour < 12) {
       recommendations.push({
         type: 'study',
@@ -220,7 +196,6 @@ const Dashboard = () => {
       });
     }
 
-    // 오후 추천 (12-18시)
     if (currentHour >= 12 && currentHour < 18) {
       recommendations.push({
         type: 'project',
@@ -232,7 +207,6 @@ const Dashboard = () => {
       });
     }
 
-    // 저녁 추천 (18-22시)
     if (currentHour >= 18 && currentHour < 22) {
       recommendations.push({
         type: 'reading',
@@ -246,38 +220,6 @@ const Dashboard = () => {
 
     return recommendations;
   };
-
-  // 마감일 데이터 (프로젝트 + 학습 과목 + 원서 학습)
-  const upcomingDeadlines = [
-    ...projects.flatMap(project => 
-      project.tasks?.filter(task => task.dueDate && task.status !== 'completed')
-        .map(task => ({
-          id: `task-${task.id}`,
-          title: `${project.name}: ${task.title}`,
-          dueDate: task.dueDate,
-          priority: task.priority,
-          type: 'project-task'
-        })) || []
-    ),
-    ...subjects.map(subject => ({
-      id: `subject-${subject.id}`,
-      title: `${subject.name} 완료`,
-      dueDate: subject.targetCompletionDate,
-      priority: subject.priority,
-      type: 'study-subject'
-    })),
-    ...textbooks.map(textbook => ({
-      id: `textbook-${textbook.id}`,
-      title: `${textbook.title} 완료`,
-      dueDate: textbook.targetDate,
-      priority: textbook.priority,
-      type: 'textbook'
-    }))
-  ].sort((a, b) => new Date(a.dueDate) - new Date(b.dueDate)).slice(0, 5);
-
-  // 오늘의 추천 학습
-  // 오늘의 추천사항 (현재 사용하지 않음)
-  // const todayRecommendations = getTodayRecommendations();
 
   // Todo 핸들러들
   const handleAddTodo = () => {
@@ -297,45 +239,11 @@ const Dashboard = () => {
     showToastMessage('새 할 일이 추가되었습니다!', 'success');
   };
 
-  const handleQuickAdd = () => {
-    if (!newTodo.text.trim()) return;
-
-    const todo = {
-      id: Date.now(),
-      text: newTodo.text,
-      completed: false,
-      priority: 'medium',
-      type: 'custom'
-    };
-
-    setTodoList(prev => [...prev, todo]);
-    setNewTodo({ text: '', priority: 'medium' });
-    setShowQuickAddModal(false);
-    showToastMessage('할 일이 빠르게 추가되었습니다!', 'success');
-  };
-
   const toggleTodo = (id) => {
     setTodoList(prev => prev.map(todo => 
       todo.id === id ? { ...todo, completed: !todo.completed } : todo
     ));
-    
-    // 실제 데이터 업데이트 (커스텀 할 일만)
-    const todo = todoList.find(t => t.id === id);
-    if (todo && todo.type === 'custom') {
-      showToastMessage(todo.completed ? '할 일을 완료 처리했습니다!' : '할 일을 미완료 처리했습니다!', 'success');
-    }
   };
-
-  // 할 일 삭제 (현재 사용하지 않음)
-  // const deleteTodo = (id) => {
-  //   const todo = todoList.find(t => t.id === id);
-  //   if (todo && todo.type === 'custom') {
-  //     setTodoList(prev => prev.filter(todo => todo.id !== id));
-  //     showToastMessage('할 일이 삭제되었습니다.', 'success');
-  //   } else {
-  //     showToastMessage('시스템 할 일은 삭제할 수 없습니다.', 'error');
-  //   }
-  // };
 
   const showToastMessage = (message, type = 'success') => {
     setToastMessage(message);
@@ -344,76 +252,32 @@ const Dashboard = () => {
     setTimeout(() => setShowToast(false), 3000);
   };
 
-  // 네비게이션 핸들러들
-  const handleNavigateToStudy = () => {
-    navigate('/study');
-  };
-
-  // 프로젝트 관리 페이지로 이동 (현재 사용하지 않음)
-  // const handleNavigateToProject = () => {
-  //   navigate('/project');
-  // };
-
-  const handleNavigateToTextbook = () => {
-    navigate('/textbook');
-  };
-
-  const handleNavigateToCalendar = () => {
-    navigate('/calendar');
-  };
-
-  const handleNavigateToTextbookDetail = (textbookId) => {
-    navigate(`/textbook/${textbookId}`);
-  };
-
-  const handleNavigateToProjectDetail = (projectId) => {
-    // 프로젝트 상세 페이지로 이동 (현재는 프로젝트 관리 페이지로)
-    navigate('/project');
-  };
-
-  // 데이터 연결 상태 확인
-  useEffect(() => {
-    console.log('Dashboard Data Status:', {
-      subjects: subjects.length,
-      textbooks: textbooks.length,
-      projects: projects.length,
-      studyLogs: studyLogs.length,
-      goals: goals.length,
-      totalStudyTime: getTotalStudyTime(),
-      completionRate: getCompletionRate(),
-      currentStreak: getCurrentStreak()
-    });
-  }, [subjects, textbooks, projects, studyLogs, goals, getTotalStudyTime, getCompletionRate, getCurrentStreak]);
-
-
-
   return (
-    <div className="min-h-screen bg-gradient-to-br from-slate-50 via-blue-50 to-indigo-50">
-      {/* 향상된 헤더 */}
-      <div className="bg-white/90 backdrop-blur-xl border-b border-slate-200/60 sticky top-0 z-50 shadow-sm">
-        <div className="max-w mx-auto px-6 py-1">
+    <div className="min-h-screen bg-slate-50">
+      {/* 상단 바 - 고정 */}
+      <div className="bg-white border-b border-slate-200 sticky top-0 z-10">
+        <div className="px-6 py-4">
           <div className="flex items-center justify-between">
-            <div className="flex items-center gap-3">
-              <div className="p-3 bg-gradient-to-br from-blue-500 to-indigo-600 rounded-xl shadow-lg">
+            {/* 페이지 제목 */}
+            <div className="flex items-center gap-4">
+              <div className="p-3 bg-slate-900 rounded-lg">
                 <Target size={24} className="text-white" />
               </div>
               <div>
-                <div className="flex items-center gap-2 mb-0.5">
+                <div className="flex items-center gap-2 mb-1">
                   {(() => {
                     const greeting = getTimeBasedGreeting();
                     const GreetingIcon = greeting.icon;
                     return (
                       <>
                         <GreetingIcon size={16} className={greeting.color} />
-                        <span className="text-xs text-slate-600">{greeting.text}</span>
+                        <span className="text-sm text-slate-600 font-medium">{greeting.text}</span>
                       </>
                     );
                   })()}
                 </div>
-                <h1 className="text-xl font-bold bg-gradient-to-r from-slate-900 to-slate-600 bg-clip-text text-transparent">
-                  대시보드
-                </h1>
-                <p className="text-xs text-slate-600 mt-0.5">
+                <h1 className="text-2xl font-bold text-slate-900">학습 대시보드</h1>
+                <p className="text-sm text-slate-600 mt-0.5">
                   {currentTime.toLocaleDateString('ko-KR', { 
                     year: 'numeric', 
                     month: 'long', 
@@ -424,41 +288,17 @@ const Dashboard = () => {
               </div>
             </div>
 
-            <div className="flex items-center gap-4">
-              {/* 빠른 통계 */}
-              <div className="hidden md:flex items-center gap-3">
-                <div className="flex items-center gap-2 bg-gradient-to-r from-orange-50 to-red-50 px-3 py-2 rounded-lg border border-orange-200/50">
-                  <Flame size={16} className="text-orange-500" />
-                  <div className="text-right">
-                    <div className="text-xs font-semibold text-orange-700">{quickStats.currentStreak}일</div>
-                    <div className="text-xs text-orange-600">연속 학습</div>
-                  </div>
-                </div>
-                <div className="flex items-center gap-2 bg-gradient-to-r from-blue-50 to-indigo-50 px-3 py-2 rounded-lg border border-blue-200/50">
-                  <Clock size={16} className="text-blue-500" />
-                  <div className="text-right">
-                    <div className="text-xs font-semibold text-blue-700">{Math.round(quickStats.totalStudyTime / 60)}h</div>
-                    <div className="text-xs text-blue-600">총 학습</div>
-                  </div>
-                </div>
-                <div className="flex items-center gap-2 bg-gradient-to-r from-green-50 to-emerald-50 px-3 py-2 rounded-lg border border-green-200/50">
-                  <Target size={16} className="text-green-500" />
-                  <div className="text-right">
-                    <div className="text-xs font-semibold text-green-700">{quickStats.completionRate}%</div>
-                    <div className="text-xs text-green-600">완료율</div>
-                  </div>
-                </div>
-              </div>
-
+            {/* 우상단 알림 및 유저 메뉴 */}
+            <div className="flex items-center gap-3">
               {/* 알림 */}
               <div className="relative">
                 <button
                   onClick={() => setShowNotifications(!showNotifications)}
-                  className="relative p-2 bg-slate-100 hover:bg-slate-200 rounded-lg transition-all duration-200"
+                  className="relative p-2 text-slate-600 hover:text-slate-800 hover:bg-slate-100 rounded-md transition-colors"
                 >
-                  <Bell size={18} className="text-slate-600" />
+                  <Bell size={24} />
                   {notifications.filter(n => n.urgent).length > 0 && (
-                    <div className="absolute -top-1 -right-1 w-4 h-4 bg-red-500 text-white rounded-full flex items-center justify-center text-xs font-bold">
+                    <div className="absolute -top-1 -right-1 w-5 h-5 bg-red-500 text-white rounded-full flex items-center justify-center text-xs font-bold">
                       {notifications.filter(n => n.urgent).length}
                     </div>
                   )}
@@ -466,26 +306,25 @@ const Dashboard = () => {
 
                 {/* 알림 드롭다운 */}
                 {showNotifications && (
-                  <div className="absolute right-0 top-14 w-80 bg-white rounded-2xl shadow-2xl border border-slate-200 z-50">
-                    <div className="p-4 border-b border-slate-100">
+                  <div className="absolute right-0 top-12 w-96 bg-white rounded-lg shadow-xl border border-slate-200 z-50">
+                    <div className="p-4 border-b border-slate-200">
                       <h3 className="font-semibold text-slate-900">알림</h3>
                     </div>
                     <div className="max-h-80 overflow-y-auto">
                       {notifications.slice(0, 5).map(notification => (
-                        <div key={notification.id} className={`p-4 border-b border-slate-50 hover:bg-slate-50 transition-colors ${notification.urgent ? 'bg-red-50' : ''}`}>
+                        <div key={notification.id} className={`p-4 border-b border-slate-100 hover:bg-slate-50 transition-colors ${notification.urgent ? 'bg-red-50' : ''}`}>
                           <div className="flex items-start gap-3">
-                            <div className={`p-1.5 rounded-lg ${
+                            <div className={`p-1.5 rounded-md ${
                               notification.type === 'study' ? 'bg-blue-100 text-blue-600' :
                               notification.type === 'project' ? 'bg-purple-100 text-purple-600' :
-                              notification.type === 'textbook' ? 'bg-green-100 text-green-600' :
                               'bg-gray-100 text-gray-600'
                             }`}>
                               {notification.type === 'study' && <Brain size={16} />}
                               {notification.type === 'project' && <Zap size={16} />}
-                              {notification.type === 'textbook' && <BookOpen size={16} />}
                             </div>
                             <div className="flex-1">
                               <p className="text-sm text-slate-900 font-medium">{notification.title}</p>
+                              <p className="text-sm text-slate-600 mt-1">{notification.message}</p>
                               <p className="text-xs text-slate-500 mt-1">{notification.time}</p>
                             </div>
                           </div>
@@ -495,148 +334,146 @@ const Dashboard = () => {
                   </div>
                 )}
               </div>
+
+              {/* 유저 메뉴 */}
+              <div className="relative">
+                <button
+                  onClick={() => setShowUserMenu(!showUserMenu)}
+                  className="flex items-center gap-2 p-2 text-slate-600 hover:text-slate-800 hover:bg-slate-100 rounded-md transition-colors"
+                >
+                  <User size={24} />
+                </button>
+
+                {/* 유저 메뉴 드롭다운 */}
+                {showUserMenu && (
+                  <div className="absolute right-0 top-12 w-64 bg-white rounded-lg shadow-xl border border-slate-200 z-50">
+                    <div className="p-4 border-b border-slate-200">
+                      <div className="flex items-center gap-3">
+                        <div className="w-10 h-10 bg-slate-900 rounded-full flex items-center justify-center">
+                          <User size={16} className="text-white" />
+                        </div>
+                        <div>
+                          <p className="font-semibold text-slate-900">학습자</p>
+                          <p className="text-sm text-slate-600">learner@example.com</p>
+                        </div>
+                      </div>
+                    </div>
+                    <div className="p-2">
+                      <button className="w-full flex items-center gap-3 px-3 py-2 hover:bg-slate-50 rounded-md transition-colors text-left">
+                        <Settings size={16} className="text-slate-600" />
+                        <span className="text-slate-700">설정</span>
+                      </button>
+                      <button className="w-full flex items-center gap-3 px-3 py-2 hover:bg-slate-50 rounded-md transition-colors text-left">
+                        <LogOut size={16} className="text-slate-600" />
+                        <span className="text-slate-700">로그아웃</span>
+                      </button>
+                    </div>
+                  </div>
+                )}
+              </div>
+            </div>
+          </div>
+
+          {/* 통계 카드들 */}
+          <div className="grid grid-cols-4 gap-4 mt-6">
+            <div className="bg-slate-100 rounded-lg p-4">
+              <div className="flex items-center gap-3">
+                <div className="p-2 bg-slate-200 rounded-lg">
+                  <BookOpen size={20} className="text-slate-600" />
+                </div>
+                <div>
+                  <div className="text-2xl font-bold text-slate-900">{quickStats.totalSubjects}</div>
+                  <div className="text-sm text-slate-600">학습 과목</div>
+                </div>
+              </div>
+            </div>
+            <div className="bg-green-50 rounded-lg p-4">
+              <div className="flex items-center gap-3">
+                <div className="p-2 bg-green-100 rounded-lg">
+                  <Target size={20} className="text-green-600" />
+                </div>
+                <div>
+                  <div className="text-2xl font-bold text-green-900">{quickStats.completionRate}%</div>
+                  <div className="text-sm text-green-600">완료율</div>
+                </div>
+              </div>
+            </div>
+            <div className="bg-blue-50 rounded-lg p-4">
+              <div className="flex items-center gap-3">
+                <div className="p-2 bg-blue-100 rounded-lg">
+                  <Clock size={20} className="text-blue-600" />
+                </div>
+                <div>
+                  <div className="text-2xl font-bold text-blue-900">{Math.round(quickStats.totalStudyTime / 60)}h</div>
+                  <div className="text-sm text-blue-600">총 학습시간</div>
+                </div>
+              </div>
+            </div>
+            <div className="bg-orange-50 rounded-lg p-4">
+              <div className="flex items-center gap-3">
+                <div className="p-2 bg-orange-100 rounded-lg">
+                  <Flame size={20} className="text-orange-600" />
+                </div>
+                <div>
+                  <div className="text-2xl font-bold text-orange-900">{quickStats.currentStreak}</div>
+                  <div className="text-sm text-orange-600">연속 학습일</div>
+                </div>
+              </div>
             </div>
           </div>
         </div>
       </div>
 
-      <div className="max-w-7xl mx-auto px-6 py-8">
-        {/* 향상된 통계 카드 */}
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 mb-8">
-          <div 
-            onClick={handleNavigateToStudy}
-            className="relative overflow-hidden bg-gradient-to-br from-blue-500 via-blue-600 to-indigo-600 rounded-3xl p-6 text-white shadow-xl shadow-blue-500/25 cursor-pointer hover:shadow-2xl transition-all duration-300"
-          >
-            <div className="relative z-10">
-              <div className="flex items-center justify-between mb-4">
-                <BookOpen size={28} className="text-blue-100" />
-                <div className="text-right">
-                  <div className="text-3xl font-bold">{quickStats.totalSubjects}</div>
-                  <div className="text-blue-100 text-sm">학습 과목</div>
-                </div>
-              </div>
-              <div className="flex items-center gap-2 text-blue-100 text-sm">
-                <TrendingUp size={16} />
-                <span>진행중 {subjects.filter(s => s.completedChapters < s.totalChapters).length}개</span>
-              </div>
-            </div>
-            <div className="absolute top-0 right-0 w-32 h-32 bg-white/10 rounded-full -translate-y-8 translate-x-8"></div>
-          </div>
-
-          <div 
-            onClick={handleNavigateToStudy}
-            className="relative overflow-hidden bg-gradient-to-br from-green-500 via-green-600 to-emerald-600 rounded-3xl p-6 text-white shadow-xl shadow-green-500/25 cursor-pointer hover:shadow-2xl transition-all duration-300"
-          >
-            <div className="relative z-10">
-              <div className="flex items-center justify-between mb-4">
-                <CheckCircle size={28} className="text-green-100" />
-                <div className="text-right">
-                  <div className="text-3xl font-bold">{quickStats.completionRate}%</div>
-                  <div className="text-green-100 text-sm">전체 완료율</div>
-                </div>
-              </div>
-              <div className="w-full bg-green-400/30 rounded-full h-2 mb-2">
-                <div 
-                  className="bg-white h-2 rounded-full transition-all duration-500"
-                  style={{ width: `${quickStats.completionRate}%` }}
-                ></div>
-              </div>
-              <div className="text-green-100 text-sm">이번 주 목표 달성</div>
-            </div>
-            <div className="absolute top-0 right-0 w-32 h-32 bg-white/10 rounded-full -translate-y-8 translate-x-8"></div>
-          </div>
-
-          <div 
-            onClick={handleNavigateToStudy}
-            className="relative overflow-hidden bg-gradient-to-br from-purple-500 via-purple-600 to-pink-600 rounded-3xl p-6 text-white shadow-xl shadow-purple-500/25 cursor-pointer hover:shadow-2xl transition-all duration-300"
-          >
-            <div className="relative z-10">
-              <div className="flex items-center justify-between mb-4">
-                <Timer size={28} className="text-purple-100" />
-                <div className="text-right">
-                  <div className="text-3xl font-bold">{Math.round(quickStats.totalStudyTime / 60)}h</div>
-                  <div className="text-purple-100 text-sm">총 학습 시간</div>
-                </div>
-              </div>
-              <div className="flex items-center gap-2 text-purple-100 text-sm">
-                <Clock size={16} />
-                <span>오늘 {Math.floor(Math.random() * 4) + 2}시간 학습</span>
-              </div>
-            </div>
-            <div className="absolute top-0 right-0 w-32 h-32 bg-white/10 rounded-full -translate-y-8 translate-x-8"></div>
-          </div>
-
-          <div 
-            onClick={handleNavigateToStudy}
-            className="relative overflow-hidden bg-gradient-to-br from-orange-500 via-red-500 to-pink-500 rounded-3xl p-6 text-white shadow-xl shadow-orange-500/25 cursor-pointer hover:shadow-2xl transition-all duration-300"
-          >
-            <div className="relative z-10">
-              <div className="flex items-center justify-between mb-4">
-                <Flame size={28} className="text-orange-100" />
-                <div className="text-right">
-                  <div className="text-3xl font-bold">{quickStats.currentStreak}</div>
-                  <div className="text-orange-100 text-sm">연속 학습일</div>
-                </div>
-              </div>
-              <div className="flex items-center gap-2 text-orange-100 text-sm">
-                <Sparkles size={16} />
-                <span>최고 기록 15일</span>
-              </div>
-            </div>
-            <div className="absolute top-0 right-0 w-32 h-32 bg-white/10 rounded-full -translate-y-8 translate-x-8"></div>
-          </div>
-        </div>
-
-        <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
+      {/* 메인 콘텐츠 */}
+      <div className="p-6">
+        <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
           {/* 왼쪽 컬럼 */}
-          <div className="lg:col-span-2 space-y-8">
+          <div className="lg:col-span-2 space-y-6">
             {/* 오늘의 집중 학습 & 타이머 */}
-            <div className="bg-white/80 backdrop-blur-xl rounded-3xl p-8 shadow-xl shadow-slate-200/50 border border-slate-200/60">
+            <div className="bg-white border border-slate-200 rounded-xl p-6">
               <div className="flex items-center justify-between mb-6">
                 <div className="flex items-center gap-3">
-                  <div className="p-3 bg-gradient-to-br from-indigo-500 to-purple-600 rounded-2xl shadow-lg">
-                    <Brain size={24} className="text-white" />
+                  <div className="p-2 bg-slate-100 rounded-lg">
+                    <Brain size={20} className="text-slate-600" />
                   </div>
                   <div>
-                    <h2 className="text-xl font-bold text-slate-900">오늘의 집중 학습</h2>
+                    <h2 className="text-lg font-semibold text-slate-900">오늘의 집중 학습</h2>
                     <p className="text-slate-600 text-sm">AI가 추천하는 최적의 학습 계획</p>
                   </div>
                 </div>
-                <div className="flex items-center gap-3">
-                  <div className="bg-gradient-to-r from-green-100 to-emerald-100 px-3 py-1.5 rounded-full border border-green-200">
-                    <span className="text-green-700 text-sm font-medium">집중도 94%</span>
-                  </div>
+                <div className="bg-green-50 px-3 py-1 rounded-full border border-green-200">
+                  <span className="text-green-700 text-sm font-medium">집중도 94%</span>
                 </div>
               </div>
 
               {/* 학습 타이머 */}
-              <div className="bg-gradient-to-br from-slate-50 to-blue-50 rounded-2xl p-6 mb-6 border border-slate-200/50">
+              <div className="bg-slate-50 rounded-lg p-4 mb-6 border border-slate-200">
                 <div className="flex items-center justify-between mb-4">
-                  <div className="flex items-center gap-3">
-                    <Timer size={20} className="text-indigo-600" />
+                  <div className="flex items-center gap-2">
+                    <Timer size={18} className="text-slate-600" />
                     <span className="font-medium text-slate-900">학습 타이머</span>
                   </div>
-                  <div className="text-2xl font-mono font-bold text-indigo-600">
+                  <div className="text-xl font-mono font-bold text-slate-900">
                     {formatTime(studyTimer.seconds)}
                   </div>
                 </div>
                 <div className="flex items-center gap-3">
                   <button
                     onClick={() => setStudyTimer(prev => ({ ...prev, isActive: !prev.isActive }))}
-                    className={`flex items-center gap-2 px-4 py-2 rounded-xl font-medium transition-all ${
+                    className={`flex items-center gap-2 px-3 py-2 rounded-lg font-medium transition-all text-sm ${
                       studyTimer.isActive 
-                        ? 'bg-red-500 hover:bg-red-600 text-white shadow-lg' 
-                        : 'bg-green-500 hover:bg-green-600 text-white shadow-lg'
+                        ? 'bg-red-500 hover:bg-red-600 text-white' 
+                        : 'bg-green-500 hover:bg-green-600 text-white'
                     }`}
                   >
-                    {studyTimer.isActive ? <Pause size={18} /> : <Play size={18} />}
+                    {studyTimer.isActive ? <Pause size={16} /> : <Play size={16} />}
                     {studyTimer.isActive ? '일시정지' : '시작하기'}
                   </button>
                   <button
                     onClick={() => setStudyTimer({ isActive: false, seconds: 0, subject: null })}
-                    className="flex items-center gap-2 px-4 py-2 rounded-xl font-medium bg-slate-200 hover:bg-slate-300 text-slate-700 transition-all"
+                    className="flex items-center gap-2 px-3 py-2 rounded-lg font-medium bg-slate-200 hover:bg-slate-300 text-slate-700 transition-all text-sm"
                   >
-                    <RotateCcw size={18} />
+                    <RotateCcw size={16} />
                     초기화
                   </button>
                 </div>
@@ -649,14 +486,14 @@ const Dashboard = () => {
                   return (
                     <div key={index} className="group hover:shadow-lg transition-all duration-300 bg-gradient-to-r from-white to-slate-50 rounded-2xl p-5 border border-slate-200/60">
                       <div className="flex items-center justify-between">
-                        <div className="flex items-center gap-4">
-                          <div className="p-3 bg-gradient-to-br from-indigo-500 to-purple-600 rounded-xl shadow-md group-hover:shadow-lg transition-all">
-                            <IconComponent size={20} className="text-white" />
+                        <div className="flex items-center gap-3">
+                          <div className="p-2 bg-slate-200 rounded-lg group-hover:bg-slate-300 transition-all">
+                            <IconComponent size={18} className="text-slate-600" />
                           </div>
                           <div>
-                            <h3 className="font-semibold text-slate-900 mb-1">{rec.title}</h3>
+                            <h3 className="font-medium text-slate-900 mb-1">{rec.title}</h3>
                             <p className="text-slate-600 text-sm mb-2">{rec.reason}</p>
-                            <div className="flex items-center gap-3">
+                            <div className="flex items-center gap-2">
                               <span className="text-xs bg-blue-100 text-blue-700 px-2 py-1 rounded-full font-medium">
                                 {rec.estimatedTime}
                               </span>
@@ -670,7 +507,7 @@ const Dashboard = () => {
                             </div>
                           </div>
                         </div>
-                        <button className="px-6 py-3 bg-gradient-to-r from-indigo-500 to-purple-600 text-white rounded-xl shadow-lg hover:shadow-xl hover:from-indigo-600 hover:to-purple-700 transition-all duration-300 font-medium">
+                        <button className="px-4 py-2 bg-slate-900 text-white rounded-lg hover:bg-slate-800 transition-all font-medium text-sm">
                           시작하기
                         </button>
                       </div>
@@ -680,17 +517,16 @@ const Dashboard = () => {
               </div>
             </div>
 
-            {/* 향상된 주간 학습 현황 */}
+            {/* 주간 학습 현황 */}
             <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-              {/* 주간 진행률 */}
-              <div className="bg-white/80 backdrop-blur-xl rounded-3xl p-6 shadow-xl shadow-slate-200/50 border border-slate-200/60">
-                <div className="flex items-center justify-between mb-6">
-                  <h3 className="text-lg font-semibold text-slate-900">주간 학습 현황</h3>
-                  <TrendingUp size={20} className="text-green-500" />
+              <div className="bg-white border border-slate-200 rounded-xl p-4">
+                <div className="flex items-center justify-between mb-4">
+                  <h3 className="font-semibold text-slate-900">주간 학습 현황</h3>
+                  <TrendingUp size={18} className="text-green-500" />
                 </div>
-                <div className="h-48">
+                <div className="h-40">
                   <ResponsiveContainer width="100%" height="100%">
-                    <AreaChart data={weeklyStudyData}>
+                    <AreaChart data={getWeeklyStudyData()}>
                       <defs>
                         <linearGradient id="colorHours" x1="0" y1="0" x2="0" y2="1">
                           <stop offset="5%" stopColor="#3b82f6" stopOpacity={0.8}/>
@@ -698,14 +534,14 @@ const Dashboard = () => {
                         </linearGradient>
                       </defs>
                       <CartesianGrid strokeDasharray="3 3" stroke="#e2e8f0" />
-                      <XAxis dataKey="day" stroke="#64748b" fontSize={12} />
-                      <YAxis stroke="#64748b" fontSize={12} />
+                      <XAxis dataKey="day" stroke="#64748b" fontSize={11} />
+                      <YAxis stroke="#64748b" fontSize={11} />
                       <Tooltip 
                         contentStyle={{
                           backgroundColor: 'white',
                           border: '1px solid #e2e8f0',
-                          borderRadius: '12px',
-                          boxShadow: '0 10px 25px -5px rgba(0, 0, 0, 0.1)'
+                          borderRadius: '8px',
+                          fontSize: '12px'
                         }}
                       />
                       <Area 
@@ -714,78 +550,80 @@ const Dashboard = () => {
                         stroke="#3b82f6" 
                         fillOpacity={1} 
                         fill="url(#colorHours)"
-                        strokeWidth={3}
+                        strokeWidth={2}
                       />
                     </AreaChart>
                   </ResponsiveContainer>
                 </div>
               </div>
 
-              {/* 과목별 성과 */}
-              <div className="bg-white/80 backdrop-blur-xl rounded-3xl p-6 shadow-xl shadow-slate-200/50 border border-slate-200/60">
-                <div className="flex items-center justify-between mb-6">
-                  <h3 className="text-lg font-semibold text-slate-900">과목별 성과</h3>
-                  <BarChart3 size={20} className="text-blue-500" />
+              <div className="bg-white border border-slate-200 rounded-xl p-4">
+                <div className="flex items-center justify-between mb-4">
+                  <h3 className="font-semibold text-slate-900">과목별 성과</h3>
+                  <BarChart3 size={18} className="text-blue-500" />
                 </div>
-                <div className="space-y-4">
-                  {subjectPerformance.map((subject, index) => (
-                    <div key={index} className="flex items-center justify-between">
-                      <div className="flex items-center gap-3">
-                        <div className="w-3 h-3 rounded-full" style={{ backgroundColor: subjects[index]?.color || '#3b82f6' }}></div>
-                        <span className="text-sm font-medium text-slate-700">{subject.name}</span>
-                      </div>
-                      <div className="flex items-center gap-3">
-                        <div className="w-20 bg-slate-200 rounded-full h-2">
-                          <div 
-                            className={`h-2 rounded-full bg-gradient-to-r ${getProgressColor(subject.progress)}`}
-                            style={{ width: `${subject.progress}%` }}
-                          ></div>
+                <div className="space-y-3">
+                  {subjects.map((subject, index) => {
+                    const progress = Math.round((subject.completedChapters / subject.totalChapters) * 100);
+                    return (
+                      <div key={index} className="flex items-center justify-between">
+                        <div className="flex items-center gap-2">
+                          <div className="w-2 h-2 rounded-full" style={{ backgroundColor: subject.color }}></div>
+                          <span className="text-sm font-medium text-slate-700">{subject.name}</span>
                         </div>
-                        <span className="text-sm text-slate-600 w-10 text-right">{subject.progress}%</span>
+                        <div className="flex items-center gap-3">
+                          <div className="w-3 h-3 rounded-full" style={{ backgroundColor: subject.color }}></div>
+                          <span className="text-sm font-medium text-slate-700">{subject.name}</span>
+                        </div>
+                        <div className="flex items-center gap-3">
+                          <div className="w-20 bg-slate-200 rounded-full h-2">
+                            <div 
+                              className={`h-2 rounded-full bg-gradient-to-r ${getProgressColor(progress)}`}
+                              style={{ width: `${progress}%` }}
+                            ></div>
+                          </div>
+                          <span className="text-sm text-slate-600 w-10 text-right">{progress}%</span>
+                        </div>
                       </div>
-                    </div>
-                  ))}
+                    );
+                  })}
                 </div>
               </div>
             </div>
 
             {/* 학습 현황 통합 섹션 */}
-            <div className="bg-white/80 backdrop-blur-xl rounded-3xl p-8 shadow-xl shadow-slate-200/50 border border-slate-200/60">
+            <div className="bg-white border border-slate-200 rounded-xl p-6">
               <div className="flex items-center justify-between mb-6">
                 <div className="flex items-center gap-3">
-                  <div className="p-3 bg-gradient-to-br from-green-500 to-emerald-600 rounded-2xl shadow-lg">
-                    <BookOpen size={24} className="text-white" />
+                  <div className="p-2 bg-slate-100 rounded-lg">
+                    <BookOpen size={20} className="text-slate-600" />
                   </div>
                   <div>
-                    <h2 className="text-xl font-bold text-slate-900">학습 현황</h2>
+                    <h2 className="text-lg font-semibold text-slate-900">학습 현황</h2>
                     <p className="text-slate-600 text-sm">진행중인 모든 학습 활동</p>
                   </div>
                 </div>
-                <div className="flex items-center gap-2">
-                  <select 
-                    className="px-3 py-2 bg-slate-100 border border-slate-200 rounded-xl text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
-                  >
-                    <option value="all">전체</option>
-                    <option value="active">진행중</option>
-                    <option value="completed">완료</option>
-                  </select>
-                </div>
+                <select className="px-3 py-1.5 bg-slate-50 border border-slate-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-500">
+                  <option value="all">전체</option>
+                  <option value="active">진행중</option>
+                  <option value="completed">완료</option>
+                </select>
               </div>
 
               {/* 학습 과목 */}
               <div className="mb-8">
                 <h3 className="text-md font-semibold text-slate-800 mb-4 flex items-center gap-2">
-                  <Brain size={18} className="text-blue-500" />
+                  <Brain size={16} className="text-blue-500" />
                   학습 과목 ({subjects.length})
                 </h3>
                 <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                  {studySubjects.slice(0, 4).map(subject => {
+                  {subjects.map(subject => {
                     const progress = Math.round((subject.completedChapters / subject.totalChapters) * 100);
                     return (
-                      <div key={subject.id} className="group hover:shadow-lg transition-all duration-300 bg-gradient-to-r from-white to-slate-50 rounded-2xl p-5 border border-slate-200/60">
-                        <div className="flex items-center justify-between mb-4">
+                      <div key={subject.id} className="group hover:border-slate-300 transition-all duration-200 bg-slate-50 rounded-lg p-4 border border-slate-200">
+                        <div className="flex items-center justify-between mb-3">
                           <div className="flex items-center gap-3">
-                            <div className="w-12 h-12 rounded-2xl flex items-center justify-center text-white font-bold shadow-lg" style={{ backgroundColor: subject.color }}>
+                            <div className="w-10 h-10 rounded-lg flex items-center justify-center text-white font-bold text-lg" style={{ backgroundColor: subject.color }}>
                               📚
                             </div>
                             <div>
@@ -802,19 +640,22 @@ const Dashboard = () => {
                           </span>
                         </div>
                         <div className="mb-3">
-                          <div className="flex items-center justify-between mb-2">
+                          <div className="flex items-center justify-between mb-1">
                             <span className="text-sm text-slate-600">진행률</span>
                             <span className="text-sm font-semibold text-slate-900">{progress}%</span>
                           </div>
-                          <div className="w-full bg-slate-200 rounded-full h-2.5">
+                          <div className="w-full bg-slate-200 rounded-full h-2">
                             <div 
-                              className={`h-2.5 rounded-full bg-gradient-to-r ${getProgressColor(progress)} transition-all duration-500`}
-                              style={{ width: `${progress}%` }}
+                              className="h-2 rounded-full transition-all duration-500"
+                              style={{ 
+                                width: `${progress}%`, 
+                                backgroundColor: subject.color 
+                              }}
                             ></div>
                           </div>
                         </div>
                         <div className="flex items-center justify-between text-xs text-slate-500">
-                          <span>최근 활동: {subject.recentActivity || '오늘'}</span>
+                          <span>최근 활동: 오늘</span>
                           <button className="text-blue-600 hover:text-blue-700 font-medium">자세히 →</button>
                         </div>
                       </div>
@@ -826,52 +667,37 @@ const Dashboard = () => {
               {/* 프로젝트 */}
               <div className="mb-8">
                 <h3 className="text-md font-semibold text-slate-800 mb-4 flex items-center gap-2">
-                  <Zap size={18} className="text-purple-500" />
+                  <Zap size={16} className="text-purple-500" />
                   프로젝트 ({projects.length})
                 </h3>
-                <div className="space-y-4">
-                  {currentProjects.slice(0, 3).map(project => {
-                    const daysLeft = project.dueDate ? getDaysUntilDeadline(project.dueDate) : null;
+                <div className="space-y-3">
+                  {projects.map(project => {
                     return (
-                      <div key={project.id} className="group hover:shadow-lg transition-all duration-300 bg-gradient-to-r from-white to-slate-50 rounded-2xl p-5 border border-slate-200/60">
+                      <div key={project.id} className="group hover:border-slate-300 transition-all duration-200 bg-slate-50 rounded-lg p-4 border border-slate-200">
                         <div className="flex items-center justify-between">
                           <div className="flex items-center gap-4">
-                            <div className="text-3xl">{project.icon}</div>
+                            <div className="text-2xl">{project.icon}</div>
                             <div>
                               <h4 className="font-semibold text-slate-900 mb-1">{project.name}</h4>
                               <p className="text-sm text-slate-600 mb-2">{project.description}</p>
-                              <div className="flex items-center gap-3">
-                                <span className={`text-xs px-2 py-1 rounded-full font-medium ${
-                                  project.priority === 'high' ? 'bg-red-100 text-red-700' :
-                                  project.priority === 'medium' ? 'bg-yellow-100 text-yellow-700' :
-                                  'bg-green-100 text-green-700'
-                                }`}>
-                                  {project.priority === 'high' ? '높음' : project.priority === 'medium' ? '보통' : '낮음'}
-                                </span>
-                                {daysLeft && (
-                                  <span className={`text-xs px-2 py-1 rounded-full font-medium ${
-                                    daysLeft <= 3 ? 'bg-red-100 text-red-700' :
-                                    daysLeft <= 7 ? 'bg-yellow-100 text-yellow-700' :
-                                    'bg-green-100 text-green-700'
-                                  }`}>
-                                    {daysLeft > 0 ? `${daysLeft}일 남음` : '마감 임박'}
-                                  </span>
-                                )}
-                              </div>
+                              <span className={`text-xs px-2 py-1 rounded-full font-medium ${
+                                project.priority === 'high' ? 'bg-red-100 text-red-700' :
+                                project.priority === 'medium' ? 'bg-yellow-100 text-yellow-700' :
+                                'bg-green-100 text-green-700'
+                              }`}>
+                                {project.priority === 'high' ? '높음' : project.priority === 'medium' ? '보통' : '낮음'}
+                              </span>
                             </div>
                           </div>
                           <div className="text-right">
-                            <div className="text-2xl font-bold text-slate-900 mb-1">{project.progress}%</div>
-                            <div className="w-24 bg-slate-200 rounded-full h-2 mb-2">
+                            <div className="text-xl font-bold text-slate-900 mb-1">{project.progress}%</div>
+                            <div className="w-20 bg-slate-200 rounded-full h-2 mb-2">
                               <div 
-                                className={`h-2 rounded-full bg-gradient-to-r ${getProgressColor(project.progress)} transition-all duration-500`}
+                                className="h-2 rounded-full bg-blue-500 transition-all duration-500"
                                 style={{ width: `${project.progress}%` }}
                               ></div>
                             </div>
-                            <button 
-                              onClick={() => handleNavigateToProjectDetail(project.id)}
-                              className="text-sm text-blue-600 hover:text-blue-700 font-medium hover:underline cursor-pointer"
-                            >
+                            <button className="text-sm text-blue-600 hover:text-blue-700 font-medium">
                               관리 →
                             </button>
                           </div>
@@ -885,53 +711,37 @@ const Dashboard = () => {
               {/* 원서 학습 */}
               <div>
                 <h3 className="text-md font-semibold text-slate-800 mb-4 flex items-center gap-2">
-                  <BookMarked size={18} className="text-green-500" />
+                  <BookMarked size={16} className="text-green-500" />
                   원서 학습 ({textbooks.length})
                 </h3>
-                <div className="space-y-4">
-                  {textbooks.slice(0, 3).map(textbook => {
+                <div className="space-y-3">
+                  {textbooks.map(textbook => {
                     const progress = Math.round((textbook.currentPage / textbook.totalPages) * 100);
-                    const daysLeft = textbook.targetDate ? getDaysUntilDeadline(textbook.targetDate) : null;
                     return (
-                      <div 
-                        key={textbook.id} 
-                        className="group hover:shadow-lg transition-all duration-300 bg-gradient-to-r from-white to-slate-50 rounded-2xl p-5 border border-slate-200/60 cursor-pointer"
-                        onClick={() => handleNavigateToTextbookDetail(textbook.id)}
-                      >
+                      <div key={textbook.id} className="group hover:border-slate-300 transition-all duration-200 bg-slate-50 rounded-lg p-4 border border-slate-200 cursor-pointer">
                         <div className="flex items-center justify-between">
                           <div className="flex items-center gap-4">
-                            <div className="w-12 h-16 bg-gradient-to-b from-green-400 to-green-600 rounded-lg flex items-center justify-center text-white text-xl shadow-lg">
+                            <div className="w-10 h-12 bg-green-500 rounded-lg flex items-center justify-center text-white text-lg">
                               📖
                             </div>
                             <div>
                               <h4 className="font-semibold text-slate-900 mb-1">{textbook.title}</h4>
                               <p className="text-sm text-slate-600 mb-2">{textbook.author}</p>
-                              <div className="flex items-center gap-3">
-                                <span className="text-xs bg-blue-100 text-blue-700 px-2 py-1 rounded-full font-medium">
-                                  {textbook.currentPage}/{textbook.totalPages} 페이지
-                                </span>
-                                {daysLeft && (
-                                  <span className={`text-xs px-2 py-1 rounded-full font-medium ${
-                                    daysLeft <= 7 ? 'bg-red-100 text-red-700' :
-                                    daysLeft <= 14 ? 'bg-yellow-100 text-yellow-700' :
-                                    'bg-green-100 text-green-700'
-                                  }`}>
-                                    {daysLeft}일 남음
-                                  </span>
-                                )}
-                              </div>
+                              <span className="text-xs bg-blue-100 text-blue-700 px-2 py-1 rounded-full font-medium">
+                                {textbook.currentPage}/{textbook.totalPages} 페이지
+                              </span>
                             </div>
                           </div>
                           <div className="text-right">
-                            <div className="text-xl font-bold text-slate-900 mb-2">{progress}%</div>
-                            <div className="w-20 bg-slate-200 rounded-full h-2">
+                            <div className="text-lg font-bold text-slate-900 mb-2">{progress}%</div>
+                            <div className="w-16 bg-slate-200 rounded-full h-1.5">
                               <div 
-                                className="h-2 rounded-full bg-gradient-to-r from-green-400 to-green-600 transition-all duration-500"
+                                className="h-1.5 rounded-full bg-green-500 transition-all duration-500"
                                 style={{ width: `${progress}%` }}
                               ></div>
                             </div>
                             <div className="text-sm text-green-600 hover:text-green-700 font-medium mt-2">
-                              자세히 보기 →
+                              자세히 →
                             </div>
                           </div>
                         </div>
@@ -945,15 +755,15 @@ const Dashboard = () => {
 
           {/* 오른쪽 사이드바 */}
           <div className="space-y-6">
-            {/* 향상된 Todo 섹션 */}
-            <div className="bg-white/80 backdrop-blur-xl rounded-3xl p-6 shadow-xl shadow-slate-200/50 border border-slate-200/60">
-              <div className="flex items-center justify-between mb-6">
-                <div className="flex items-center gap-3">
-                  <div className="p-2 bg-gradient-to-br from-orange-500 to-red-600 rounded-xl shadow-lg">
-                    <CheckCircle2 size={20} className="text-white" />
+            {/* Todo 섹션 */}
+            <div className="bg-white border border-slate-200 rounded-xl p-4">
+              <div className="flex items-center justify-between mb-4">
+                <div className="flex items-center gap-2">
+                  <div className="p-1.5 bg-slate-100 rounded-lg">
+                    <CheckCircle2 size={16} className="text-slate-600" />
                   </div>
                   <div>
-                    <h3 className="text-lg font-semibold text-slate-900">오늘 할 일</h3>
+                    <h3 className="font-semibold text-slate-900">오늘 할 일</h3>
                     <p className="text-xs text-slate-600">
                       {todoList.filter(t => !t.completed).length}개 남음
                     </p>
@@ -961,45 +771,45 @@ const Dashboard = () => {
                 </div>
                 <button 
                   onClick={() => setShowAddTodoModal(true)}
-                  className="p-2 bg-blue-500 hover:bg-blue-600 text-white rounded-xl transition-all shadow-lg hover:shadow-xl"
+                  className="p-1.5 bg-slate-900 hover:bg-slate-800 text-white rounded-lg transition-all"
                 >
-                  <Plus size={18} />
+                  <Plus size={16} />
                 </button>
               </div>
 
-              <div className="space-y-3 max-h-96 overflow-y-auto">
+              <div className="space-y-2 max-h-80 overflow-y-auto">
                 {todoList.slice(0, 5).map(todo => (
-                  <div key={todo.id} className={`group p-4 rounded-2xl border transition-all duration-300 ${
+                  <div key={todo.id} className={`group p-3 rounded-lg border transition-all duration-200 ${
                     todo.completed 
                       ? 'bg-green-50 border-green-200 opacity-75' 
-                      : 'bg-white border-slate-200 hover:shadow-md'
+                      : 'bg-slate-50 border-slate-200 hover:border-slate-300'
                   }`}>
-                    <div className="flex items-start gap-3">
+                    <div className="flex items-start gap-2">
                       <button
                         onClick={() => toggleTodo(todo.id)}
-                        className={`mt-0.5 w-5 h-5 rounded-full border-2 flex items-center justify-center transition-all ${
+                        className={`mt-0.5 w-4 h-4 rounded-full border-2 flex items-center justify-center transition-all ${
                           todo.completed
                             ? 'bg-green-500 border-green-500 text-white'
                             : 'border-slate-300 hover:border-blue-500'
                         }`}
                       >
-                        {todo.completed && <CheckCircle2 size={12} />}
+                        {todo.completed && <CheckCircle2 size={10} />}
                       </button>
                       <div className="flex-1">
-                        <p className={`font-medium ${
+                        <p className={`font-medium text-sm ${
                           todo.completed ? 'text-slate-500 line-through' : 'text-slate-900'
                         }`}>
                           {todo.text}
                         </p>
-                        <div className="flex items-center gap-2 mt-2">
-                          <span className={`text-xs px-2 py-1 rounded-full font-medium ${
+                        <div className="flex items-center gap-1 mt-1">
+                          <span className={`text-xs px-1.5 py-0.5 rounded-full font-medium ${
                             todo.priority === 'high' ? 'bg-red-100 text-red-700' :
                             todo.priority === 'medium' ? 'bg-yellow-100 text-yellow-700' :
                             'bg-green-100 text-green-700'
                           }`}>
                             {todo.priority === 'high' ? '높음' : todo.priority === 'medium' ? '보통' : '낮음'}
                           </span>
-                          <span className="text-xs bg-slate-100 text-slate-600 px-2 py-1 rounded-full">
+                          <span className="text-xs bg-slate-100 text-slate-600 px-1.5 py-0.5 rounded-full">
                             {todo.type}
                           </span>
                         </div>
@@ -1009,79 +819,67 @@ const Dashboard = () => {
                 ))}
               </div>
 
-              <div className="mt-4 pt-4 border-t border-slate-200">
+              <div className="mt-3 pt-3 border-t border-slate-200">
                 <div className="flex items-center justify-between text-sm">
                   <span className="text-slate-600">
                     완료: {todoList.filter(t => t.completed).length}/{todoList.length}
                   </span>
                   <span className="text-slate-600">
-                    예상 시간: {todoList.filter(t => !t.completed).reduce((acc, t) => acc + (t.estimatedTime || 30), 0)}분
+                    예상: {todoList.filter(t => !t.completed).length * 30}분
                   </span>
                 </div>
               </div>
             </div>
 
             {/* 빠른 작업 */}
-            <div className="bg-white/80 backdrop-blur-xl rounded-3xl p-6 shadow-xl shadow-slate-200/50 border border-slate-200/60">
-              <h3 className="text-lg font-semibold text-slate-900 mb-4 flex items-center gap-2">
-                <Zap size={20} className="text-yellow-500" />
+            <div className="bg-white border border-slate-200 rounded-xl p-4">
+              <h3 className="font-semibold text-slate-900 mb-3 flex items-center gap-2">
+                <Zap size={16} className="text-yellow-500" />
                 빠른 작업
               </h3>
-              <div className="space-y-3">
-                <button 
-                  onClick={handleNavigateToStudy}
-                  className="w-full flex items-center gap-3 p-3 bg-gradient-to-r from-blue-50 to-indigo-50 hover:from-blue-100 hover:to-indigo-100 rounded-2xl border border-blue-200/50 transition-all text-left cursor-pointer"
-                >
-                  <div className="p-2 bg-blue-500 rounded-xl">
-                    <Plus size={16} className="text-white" />
+              <div className="space-y-2">
+                <button className="w-full flex items-center gap-3 p-3 bg-blue-50 hover:bg-blue-100 rounded-lg border border-blue-200 transition-all text-left">
+                  <div className="p-1.5 bg-blue-500 rounded-lg">
+                    <Plus size={14} className="text-white" />
                   </div>
-                  <span className="font-medium text-blue-900">새 학습 세션 시작</span>
+                  <span className="font-medium text-blue-900 text-sm">새 학습 세션 시작</span>
                 </button>
-                <button 
-                  onClick={handleNavigateToTextbook}
-                  className="w-full flex items-center gap-3 p-3 bg-gradient-to-r from-green-50 to-emerald-50 hover:from-green-100 hover:to-emerald-100 rounded-2xl border border-green-200/50 transition-all text-left cursor-pointer"
-                >
-                  <div className="p-2 bg-green-500 rounded-xl">
-                    <BookOpen size={16} className="text-white" />
+                <button className="w-full flex items-center gap-3 p-3 bg-green-50 hover:bg-green-100 rounded-lg border border-green-200 transition-all text-left">
+                  <div className="p-1.5 bg-green-500 rounded-lg">
+                    <BookOpen size={14} className="text-white" />
                   </div>
-                  <span className="font-medium text-green-900">복습 노트 작성</span>
+                  <span className="font-medium text-green-900 text-sm">복습 노트 작성</span>
                 </button>
-                <button 
-                  onClick={handleNavigateToStudy}
-                  className="w-full flex items-center gap-3 p-3 bg-gradient-to-r from-purple-50 to-pink-50 hover:from-purple-100 hover:to-pink-100 rounded-2xl border border-purple-200/50 transition-all text-left cursor-pointer"
-                >
-                  <div className="p-2 bg-purple-500 rounded-xl">
-                    <Target size={16} className="text-white" />
+                <button className="w-full flex items-center gap-3 p-3 bg-purple-50 hover:bg-purple-100 rounded-lg border border-purple-200 transition-all text-left">
+                  <div className="p-1.5 bg-purple-500 rounded-lg">
+                    <Target size={14} className="text-white" />
                   </div>
-                  <span className="font-medium text-purple-900">목표 설정</span>
+                  <span className="font-medium text-purple-900 text-sm">목표 설정</span>
                 </button>
               </div>
             </div>
 
             {/* 다가오는 마감일 */}
-            <div className="bg-white/80 backdrop-blur-xl rounded-3xl p-6 shadow-xl shadow-slate-200/50 border border-slate-200/60">
-              <div className="flex items-center justify-between mb-4">
-                <h3 className="text-lg font-semibold text-slate-900 flex items-center gap-2">
-                  <Calendar size={20} className="text-red-500" />
+            <div className="bg-white border border-slate-200 rounded-xl p-4">
+              <div className="flex items-center justify-between mb-3">
+                <h3 className="font-semibold text-slate-900 flex items-center gap-2">
+                  <Calendar size={16} className="text-red-500" />
                   다가오는 마감일
                 </h3>
-                <button 
-                  onClick={handleNavigateToCalendar}
-                  className="text-sm text-blue-600 hover:text-blue-700 font-medium hover:underline cursor-pointer"
-                >
+                <button className="text-sm text-blue-600 hover:text-blue-700 font-medium">
                   전체보기
                 </button>
               </div>
-              <div className="space-y-3">
+              <div className="space-y-2">
                 {upcomingDeadlines.slice(0, 4).map((deadline, index) => {
                   const daysLeft = getDaysUntilDeadline(deadline.dueDate);
                   return (
-                    <div key={index} className={`p-4 rounded-2xl border transition-all hover:shadow-md ${
+                    <div key={index} className={`p-3 rounded-lg border transition-all ${
                       daysLeft <= 3 ? 'bg-red-50 border-red-200' :
                       daysLeft <= 7 ? 'bg-yellow-50 border-yellow-200' :
                       'bg-slate-50 border-slate-200'
                     }`}>
-                      <div className="flex items-center justify-between mb-2">
+                      <div className="flex items-center justify-between mb-1">
                         <h4 className="font-medium text-slate-900 text-sm">{deadline.title}</h4>
                         <span className={`text-xs px-2 py-1 rounded-full font-medium ${
                           daysLeft <= 3 ? 'bg-red-100 text-red-700' :
@@ -1104,16 +902,16 @@ const Dashboard = () => {
             </div>
 
             {/* 성취 배지 */}
-            <div className="bg-gradient-to-br from-yellow-400 via-orange-500 to-red-500 rounded-3xl p-6 text-white shadow-xl shadow-orange-500/25">
+            <div className="bg-gradient-to-br from-yellow-400 via-orange-500 to-red-500 rounded-xl p-4 text-white">
               <div className="text-center">
-                <div className="text-4xl mb-3">🏆</div>
-                <h3 className="text-lg font-bold mb-2">이번 주 MVP!</h3>
-                <p className="text-yellow-100 text-sm mb-4">
+                <div className="text-3xl mb-2">🏆</div>
+                <h3 className="font-bold mb-2">이번 주 MVP!</h3>
+                <p className="text-yellow-100 text-sm mb-3">
                   {quickStats.currentStreak}일 연속 학습 달성으로<br />
                   꾸준함 배지를 획득했습니다
                 </p>
                 <div className="flex items-center justify-center gap-2 text-yellow-100 text-sm">
-                  <Sparkles size={16} />
+                  <Sparkles size={14} />
                   <span>다음 목표: 15일 연속</span>
                 </div>
               </div>
@@ -1122,78 +920,63 @@ const Dashboard = () => {
         </div>
       </div>
 
-      {/* 모달들 */}
-      <Modal
-        isOpen={showAddTodoModal}
-        onClose={() => setShowAddTodoModal(false)}
-        title="새 할 일 추가"
-      >
-        <div className="space-y-4">
-          <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">할 일</label>
-            <input
-              type="text"
-              value={newTodo.text}
-              onChange={(e) => setNewTodo(prev => ({ ...prev, text: e.target.value }))}
-              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
-              placeholder="할 일을 입력하세요"
-            />
-          </div>
-          <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">우선순위</label>
-            <select
-              value={newTodo.priority}
-              onChange={(e) => setNewTodo(prev => ({ ...prev, priority: e.target.value }))}
-              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
-            >
-              <option value="low">낮음</option>
-              <option value="medium">보통</option>
-              <option value="high">높음</option>
-            </select>
-          </div>
-          <div className="flex gap-3 pt-4">
-            <Button onClick={() => setShowAddTodoModal(false)} variant="outline" className="flex-1">
-              취소
-            </Button>
-            <Button onClick={handleAddTodo} className="flex-1">
-              추가
-            </Button>
-          </div>
-        </div>
-      </Modal>
-
-      <Modal
-        isOpen={showQuickAddModal}
-        onClose={() => setShowQuickAddModal(false)}
-        title="빠른 할 일 추가"
-      >
-        <div className="space-y-4">
-          <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">할 일</label>
-            <input
-              type="text"
-              value={newTodo.text}
-              onChange={(e) => setNewTodo(prev => ({ ...prev, text: e.target.value }))}
-              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
-              placeholder="할 일을 입력하세요"
-              onKeyPress={(e) => e.key === 'Enter' && handleQuickAdd()}
-            />
-          </div>
-          <div className="flex gap-3 pt-4">
-            <Button onClick={() => setShowQuickAddModal(false)} variant="outline" className="flex-1">
-              취소
-            </Button>
-            <Button onClick={handleQuickAdd} className="flex-1">
-              추가
-            </Button>
+      {/* 모달 */}
+      {showAddTodoModal && (
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
+          <div className="bg-white rounded-xl p-6 w-full max-w-md">
+            <h3 className="text-lg font-semibold text-slate-900 mb-4">새 할 일 추가</h3>
+            <div className="space-y-4">
+              <div>
+                <label className="block text-sm font-medium text-slate-700 mb-1">할 일</label>
+                <input
+                  type="text"
+                  value={newTodo.text}
+                  onChange={(e) => setNewTodo(prev => ({ ...prev, text: e.target.value }))}
+                  className="w-full px-3 py-2 border border-slate-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
+                  placeholder="할 일을 입력하세요"
+                />
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-slate-700 mb-1">우선순위</label>
+                <select
+                  value={newTodo.priority}
+                  onChange={(e) => setNewTodo(prev => ({ ...prev, priority: e.target.value }))}
+                  className="w-full px-3 py-2 border border-slate-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
+                >
+                  <option value="low">낮음</option>
+                  <option value="medium">보통</option>
+                  <option value="high">높음</option>
+                </select>
+              </div>
+              <div className="flex gap-3 pt-4">
+                <button 
+                  onClick={() => setShowAddTodoModal(false)}
+                  className="flex-1 px-4 py-2 border border-slate-300 rounded-lg hover:bg-slate-50 transition-colors"
+                >
+                  취소
+                </button>
+                <button 
+                  onClick={handleAddTodo}
+                  className="flex-1 px-4 py-2 bg-slate-900 text-white rounded-lg hover:bg-slate-800 transition-colors"
+                >
+                  추가
+                </button>
+              </div>
+            </div>
           </div>
         </div>
-      </Modal>
+      )}
 
       {/* 토스트 알림 */}
-      <Toast open={showToast} type={toastType}>
-        {toastMessage}
-      </Toast>
+      {showToast && (
+        <div className="fixed top-4 right-4 z-50">
+          <div className={`px-4 py-3 rounded-lg shadow-lg ${
+            toastType === 'success' ? 'bg-green-500 text-white' : 'bg-red-500 text-white'
+          }`}>
+            {toastMessage}
+          </div>
+        </div>
+      )}
     </div>
   );
 };

--- a/src/pages/Dashboard/index.js
+++ b/src/pages/Dashboard/index.js
@@ -1,30 +1,29 @@
-import React, { useState, useEffect } from 'react';
-import { Clock, Target, CheckCircle, Bell, BookOpen, TrendingUp, Flame, Calendar, Plus, Zap, Brain, Timer, BarChart3, BookMarked, CheckCircle2, Play, Pause, RotateCcw, Sparkles, Sun, Moon, Sunrise, Settings, User, LogOut, MoreHorizontal } from 'lucide-react';
+import React, { useState, useEffect, useMemo } from 'react';
+import { Clock, Target, Bell, BookOpen, TrendingUp, Flame, Calendar, Plus, Zap, Brain, Timer, BarChart3, BookMarked, CheckCircle2, Play, Pause, RotateCcw, Sparkles, Sun, Moon, Sunrise, Settings, User, LogOut } from 'lucide-react';
 import { XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, AreaChart, Area } from 'recharts';
 
 const Dashboard = () => {
   // Mock data - 실제로는 context에서 가져올 데이터
-  const subjects = [
+  const subjects = useMemo(() => [
     { id: 1, name: '알고리즘', completedChapters: 8, totalChapters: 12, priority: 'high', color: '#3b82f6' },
     { id: 2, name: '데이터베이스', completedChapters: 6, totalChapters: 10, priority: 'medium', color: '#10b981' },
     { id: 3, name: '운영체제', completedChapters: 4, totalChapters: 8, priority: 'medium', color: '#f59e0b' }
-  ];
+  ], []);
 
-  const projects = [
+  const projects = useMemo(() => [
     { id: 1, name: '캡스톤 프로젝트', description: 'AI 기반 학습 관리 시스템', progress: 75, status: 'in-progress', priority: 'high', icon: '🚀' },
     { id: 2, name: '웹 포트폴리오', description: '개인 포트폴리오 웹사이트 제작', progress: 45, status: 'in-progress', priority: 'medium', icon: '💼' }
-  ];
+  ], []);
 
-  const textbooks = [
+  const textbooks = useMemo(() => [
     { id: 1, title: 'Clean Code', author: 'Robert Martin', currentPage: 120, totalPages: 400, priority: 'high' },
     { id: 2, title: 'System Design Interview', author: 'Alex Xu', currentPage: 80, totalPages: 300, priority: 'medium' }
-  ];
-
-  const studyLogs = [];
-  const goals = [
+  ], []);
+  
+  const goals = useMemo(() => [
     { id: 1, title: '알고리즘 마스터', progress: 80 },
     { id: 2, title: '프로젝트 완성', progress: 75 }
-  ];
+  ], []);
 
   // 실제 데이터에서 Todo 목록 생성
   const [todoList, setTodoList] = useState([]);
@@ -56,7 +55,7 @@ const Dashboard = () => {
       }))
     ];
     setTodoList(todos);
-  }, []);
+  }, [subjects, projects, textbooks]);
 
   // 모달 상태
   const [showAddTodoModal, setShowAddTodoModal] = useState(false);

--- a/src/pages/ProjectManagement/index.js
+++ b/src/pages/ProjectManagement/index.js
@@ -1,10 +1,11 @@
 import { useState, useMemo } from 'react';
 import { 
-  Plus, Search, Briefcase, Filter, X
+  Plus, Search, Briefcase, Filter, X,
+  TrendingUp, CheckCircle, DollarSign,
+  Clock, BarChart3, List, Calendar, PieChart
 } from 'lucide-react';
 
 import ProjectModal from '../../components/project/ProjectModal';
-import ViewSelector from '../../components/project/ViewSelector';
 import BoardView from '../../components/project/BoardView';
 import ListView from '../../components/project/ListView';
 import TimelineView from '../../components/project/TimelineView';
@@ -33,6 +34,7 @@ export default function AdvancedProjectManagement() {
     const totalProjects = projects.length;
     const completedProjects = projects.filter(p => p.status === 'completed').length;
     const inProgressProjects = projects.filter(p => p.status === 'in-progress').length;
+    const notStartedProjects = projects.filter(p => p.status === 'not-started').length;
     const overallProgress = totalProjects > 0 ? (completedProjects / totalProjects) * 100 : 0;
     
     const totalTasks = projects.reduce((acc, p) => acc + (p.tasks?.length || 0), 0);
@@ -48,6 +50,7 @@ export default function AdvancedProjectManagement() {
       totalProjects,
       completedProjects,
       inProgressProjects,
+      notStartedProjects,
       overallProgress,
       totalTasks,
       completedTasks,
@@ -78,198 +81,294 @@ export default function AdvancedProjectManagement() {
     addProject(newProject);
   };
 
+  const formatCurrency = (amount) => {
+    return new Intl.NumberFormat('ko-KR', {
+      style: 'currency',
+      currency: 'KRW',
+      minimumFractionDigits: 0
+    }).format(amount);
+  };
+
   return (
-    <div className="min-h-screen bg-gradient-to-br from-slate-50 via-blue-50 to-indigo-50">
-      {/* Responsive Header */}
-      <div className="bg-white/95 backdrop-blur-xl border-b border-slate-200/60 sticky top-0 z-20 shadow-sm">
-        <div className="w-full px-4 sm:px-6 py-3">
-          {/* Mobile and Desktop Header Layout */}
-          <div className="flex items-center justify-between gap-2 sm:gap-3">
-            {/* Left side - Logo and Title */}
-            <div className="flex items-center gap-2 sm:gap-3 min-w-0 flex-1">
-              <div className="p-2 bg-gradient-to-br from-indigo-500 via-purple-500 to-pink-500 rounded-lg shadow-lg flex-shrink-0">
-                <Briefcase size={20} className="text-white sm:w-6 sm:h-6" />
-              </div>
-              <div className="min-w-0 flex-1">
-                <h1 className="text-lg sm:text-xl font-bold bg-gradient-to-r from-slate-900 to-slate-600 bg-clip-text text-transparent truncate">
-                  프로젝트 관리
-                </h1>
-                <p className="text-xs text-slate-600 mt-0.5 truncate hidden sm:block">
-                  팀 협업과 프로젝트 진행을 관리하세요
-                </p>
-              </div>
+    <div className="min-h-screen bg-slate-50">
+      {/* 상단 헤더 바 (원서 관리와 동일한 구조) */}
+      <div className="bg-white border-b border-slate-200 sticky top-0 z-20">
+        <div className="px-6 py-4">
+          <div className="flex items-center justify-between">
+            {/* 페이지 제목 */}
+            <div>
+              <h1 className="text-2xl font-bold text-slate-900">프로젝트 관리</h1>
+              <p className="text-sm text-slate-600 mt-0.5">팀 협업과 프로젝트 진행을 관리하세요</p>
             </div>
-            
-            {/* Right side - Action Button */}
-            <div className="flex-shrink-0">
+
+            {/* 우측 액션 버튼들 */}
+            <div className="flex items-center gap-3">
+              <div className="flex items-center gap-2 bg-slate-50/80 backdrop-blur px-3 py-2 rounded-lg border border-slate-200/50">
+                <TrendingUp size={16} className="text-blue-500" />
+                <span className="text-xs text-slate-600">{Math.round(analytics.overallProgress)}% 완료</span>
+              </div>
+              <div className="flex items-center gap-2 bg-slate-50/80 backdrop-blur px-3 py-2 rounded-lg border border-slate-200/50">
+                <Clock size={16} className="text-emerald-500" />
+                <span className="text-xs text-slate-600">{analytics.inProgressProjects}개 진행중</span>
+              </div>
               <button 
                 onClick={() => setShowProjectModal(true)}
-                className="px-3 py-2 sm:px-4 sm:py-2.5 bg-gradient-to-r from-indigo-500 to-purple-500 text-white rounded-lg sm:rounded-xl shadow-lg hover:shadow-xl hover:from-indigo-600 hover:to-purple-600 transition-all duration-300 flex items-center gap-1 sm:gap-2 font-medium text-sm sm:text-base"
+                className="bg-slate-900 text-white px-4 py-2 rounded-md text-sm font-medium hover:bg-slate-800 transition-colors flex items-center gap-2"
               >
-                <Plus size={16} className="sm:w-[18px] sm:h-[18px]" />
-                <span className="hidden sm:inline">새 프로젝트</span>
-                <span className="sm:hidden">추가</span>
+                <Plus size={16} />
+                새 프로젝트
               </button>
             </div>
           </div>
-        </div>
-      </div>
-      
-      <div className="w-full max-w-7xl mx-auto px-4 sm:px-6 py-4 sm:py-6">
-        {/* Search and Filters Section */}
-        <div className="mb-4 sm:mb-6 space-y-4">
-          {/* Search Bar */}
-          <div className="relative">
-            <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 w-4 h-4 text-slate-400" />
-            <input
-              type="text"
-              placeholder="프로젝트, 작업, 팀원 검색..."
-              value={searchQuery}
-              onChange={(e) => setSearchQuery(e.target.value)}
-              className="w-full pl-10 pr-12 sm:pr-4 py-2.5 border border-slate-200 rounded-lg focus:ring-2 focus:ring-indigo-500 focus:border-transparent bg-white shadow-sm text-sm sm:text-base"
-            />
-            {/* Mobile Filter Toggle */}
-            <button
-              onClick={() => setShowFilters(!showFilters)}
-              className="absolute right-3 top-1/2 transform -translate-y-1/2 p-1 text-slate-400 hover:text-slate-600 sm:hidden"
-            >
-              <Filter size={16} />
-            </button>
-          </div>
-          
-          {/* Desktop Filters - Always visible on desktop */}
-          <div className="hidden sm:flex items-center gap-3 flex-wrap">
-            <select 
-              value={filters.status} 
-              onChange={(e) => setFilters({...filters, status: e.target.value})}
-              className="px-3 py-2.5 border border-slate-200 rounded-lg text-sm focus:ring-2 focus:ring-indigo-500 bg-white shadow-sm min-w-0"
-            >
-              <option value="all">모든 상태</option>
-              <option value="not-started">시작 전</option>
-              <option value="in-progress">진행 중</option>
-              <option value="completed">완료</option>
-              <option value="on-hold">보류</option>
-            </select>
-            
-            <select 
-              value={filters.priority} 
-              onChange={(e) => setFilters({...filters, priority: e.target.value})}
-              className="px-3 py-2.5 border border-slate-200 rounded-lg text-sm focus:ring-2 focus:ring-indigo-500 bg-white shadow-sm min-w-0"
-            >
-              <option value="all">모든 우선순위</option>
-              <option value="critical">긴급</option>
-              <option value="high">높음</option>
-              <option value="medium">보통</option>
-              <option value="low">낮음</option>
-            </select>
-          </div>
-          
-          {/* Mobile Filters - Collapsible */}
-          {showFilters && (
-            <div className="sm:hidden bg-white rounded-lg border border-slate-200 p-4 shadow-sm space-y-3">
-              <div className="flex items-center justify-between">
-                <h3 className="font-medium text-slate-900">필터</h3>
-                <button
-                  onClick={() => setShowFilters(false)}
-                  className="p-1 text-slate-400 hover:text-slate-600"
-                >
-                  <X size={16} />
-                </button>
-              </div>
-              
-              <div className="space-y-3">
-                <div>
-                  <label className="block text-sm font-medium text-slate-700 mb-1">상태</label>
-                  <select 
-                    value={filters.status} 
-                    onChange={(e) => setFilters({...filters, status: e.target.value})}
-                    className="w-full px-3 py-2 border border-slate-200 rounded-lg text-sm focus:ring-2 focus:ring-indigo-500 bg-white"
-                  >
-                    <option value="all">모든 상태</option>
-                    <option value="not-started">시작 전</option>
-                    <option value="in-progress">진행 중</option>
-                    <option value="completed">완료</option>
-                    <option value="on-hold">보류</option>
-                  </select>
+
+          {/* 통계 카드들 (원서 관리와 동일한 구조) */}
+          <div className="grid grid-cols-4 gap-4 mt-6">
+            <div className="bg-slate-50 rounded-lg p-4">
+              <div className="flex items-center gap-3">
+                <div className="p-2 bg-slate-100 rounded-lg">
+                  <Briefcase size={20} className="text-slate-600" />
                 </div>
-                
                 <div>
-                  <label className="block text-sm font-medium text-slate-700 mb-1">우선순위</label>
-                  <select 
-                    value={filters.priority} 
-                    onChange={(e) => setFilters({...filters, priority: e.target.value})}
-                    className="w-full px-3 py-2 border border-slate-200 rounded-lg text-sm focus:ring-2 focus:ring-indigo-500 bg-white"
-                  >
-                    <option value="all">모든 우선순위</option>
-                    <option value="critical">긴급</option>
-                    <option value="high">높음</option>
-                    <option value="medium">보통</option>
-                    <option value="low">낮음</option>
-                  </select>
+                  <div className="text-2xl font-bold text-slate-900">{analytics.totalProjects}</div>
+                  <div className="text-sm text-slate-500">전체 프로젝트</div>
                 </div>
               </div>
             </div>
-          )}
+            <div className="bg-blue-50 rounded-lg p-4">
+              <div className="flex items-center gap-3">
+                <div className="p-2 bg-blue-100 rounded-lg">
+                  <TrendingUp size={20} className="text-blue-600" />
+                </div>
+                <div>
+                  <div className="text-2xl font-bold text-blue-900">{analytics.inProgressProjects}</div>
+                  <div className="text-sm text-blue-600">진행 중</div>
+                </div>
+              </div>
+            </div>
+            <div className="bg-emerald-50 rounded-lg p-4">
+              <div className="flex items-center gap-3">
+                <div className="p-2 bg-emerald-100 rounded-lg">
+                  <CheckCircle size={20} className="text-emerald-600" />
+                </div>
+                <div>
+                  <div className="text-2xl font-bold text-emerald-900">{analytics.completedProjects}</div>
+                  <div className="text-sm text-emerald-600">완료</div>
+                </div>
+              </div>
+            </div>
+            <div className="bg-purple-50 rounded-lg p-4">
+              <div className="flex items-center gap-3">
+                <div className="p-2 bg-purple-100 rounded-lg">
+                  <DollarSign size={20} className="text-purple-600" />
+                </div>
+                <div>
+                  <div className="text-2xl font-bold text-purple-900">{formatCurrency(analytics.totalBudget)}</div>
+                  <div className="text-sm text-purple-600">총 예산</div>
+                </div>
+              </div>
+            </div>
+          </div>
         </div>
-
-        {/* View Selector - Responsive */}
-        <div className="mb-4 sm:mb-6">
-          <ViewSelector 
-            activeView={activeView}
-            setActiveView={setActiveView}
-            filteredProjectsCount={filteredProjects.length}
-          />
-        </div>
-        
-        {/* Content Views - All responsive by default */}
-        <div className="w-full overflow-hidden">
-          {activeView === 'board' && (
-            <BoardView 
-              filteredProjects={filteredProjects}
-              setSelectedProject={setSelectedProject}
-            />
-          )}
-          {activeView === 'list' && (
-            <ListView 
-              filteredProjects={filteredProjects}
-              setSelectedProject={setSelectedProject}
-            />
-          )}
-          {activeView === 'timeline' && (
-            <TimelineView 
-              filteredProjects={filteredProjects}
-              updateTask={updateTask}
-            />
-          )}
-          {activeView === 'analytics' && (
-            <AnalyticsView 
-              analytics={analytics}
-              projects={projects}
-            />
-          )}
-        </div>
-        
-        {/* Modals */}
-        <ProjectModal 
-          showModal={showProjectModal}
-          onClose={() => setShowProjectModal(false)}
-          onCreateProject={handleCreateProject}
-        />
-
-        <ProjectDetailModal 
-          selectedProject={selectedProject}
-          setSelectedProject={setSelectedProject}
-          updateTask={updateTask}
-          setShowTaskModal={setShowTaskModal}
-        />
-
-        <TaskModal 
-          showTaskModal={showTaskModal}
-          setShowTaskModal={setShowTaskModal}
-          selectedProject={selectedProject}
-          onAddTask={addTask}
-        />
       </div>
+
+      {/* 컨트롤 바 (뷰 선택 + 검색/필터) */}
+      <div className="bg-white border-b border-slate-200 px-6 py-3">
+        <div className="flex items-center justify-between">
+          {/* 뷰 선택 */}
+          <div className="flex items-center gap-1 bg-gray-200 p-1 rounded-xl">
+            {[
+              { id: 'board', name: '보드뷰', icon: BarChart3 },
+              { id: 'list', name: '리스트뷰', icon: List },
+              { id: 'timeline', name: '타임라인', icon: Calendar },
+              { id: 'analytics', name: '분석', icon: PieChart }
+            ].map(view => {
+              const Icon = view.icon;
+              return (
+                <button
+                  key={view.id}
+                  onClick={() => setActiveView(view.id)}
+                  className={`flex items-center gap-2 px-4 py-2.5 rounded-lg font-medium text-sm transition-all duration-200 ${
+                    activeView === view.id
+                      ? 'bg-white text-blue-600 shadow-sm'
+                      : 'text-slate-600 hover:text-slate-900 hover:bg-white/50'
+                  }`}
+                >
+                  <Icon size={16} />
+                  {view.name}
+                </button>
+              );
+            })}
+          </div>
+
+          {/* 검색 & 필터 */}
+          <div className="flex items-center gap-3">
+            <div className="relative">
+              <Search size={16} className="absolute left-3 top-1/2 -translate-y-1/2 text-slate-400" />
+              <input
+                type="text"
+                placeholder="프로젝트, 작업, 팀원 검색..."
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
+                className="pl-9 pr-4 py-2 border border-slate-200 rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent w-64"
+              />
+            </div>
+            
+            {/* 데스크톱 필터 */}
+            <div className="hidden sm:flex items-center gap-2">
+              <select 
+                value={filters.status} 
+                onChange={(e) => setFilters({...filters, status: e.target.value})}
+                className="px-3 py-2 border border-slate-200 rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 bg-white"
+              >
+                <option value="all">모든 상태</option>
+                <option value="not-started">시작 전</option>
+                <option value="in-progress">진행 중</option>
+                <option value="completed">완료</option>
+                <option value="on-hold">보류</option>
+              </select>
+              
+              <select 
+                value={filters.priority} 
+                onChange={(e) => setFilters({...filters, priority: e.target.value})}
+                className="px-3 py-2 border border-slate-200 rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 bg-white"
+              >
+                <option value="all">모든 우선순위</option>
+                <option value="critical">긴급</option>
+                <option value="high">높음</option>
+                <option value="medium">보통</option>
+                <option value="low">낮음</option>
+              </select>
+            </div>
+
+            {/* 모바일 필터 토글 */}
+            <button
+              onClick={() => setShowFilters(!showFilters)}
+              className="sm:hidden p-2 text-slate-400 hover:text-slate-600 border border-slate-200 rounded-md"
+            >
+              <Filter size={16} />
+            </button>
+
+            {/* 결과 수 표시 */}
+            <div className="text-sm text-slate-500">
+              {filteredProjects.length}개의 프로젝트
+            </div>
+          </div>
+        </div>
+
+        {/* 모바일 필터 섹션 */}
+        {showFilters && (
+          <div className="sm:hidden bg-white rounded-lg border border-slate-200 p-4 shadow-sm space-y-3 mt-3">
+            <div className="flex items-center justify-between">
+              <h3 className="font-medium text-slate-900">필터</h3>
+              <button
+                onClick={() => setShowFilters(false)}
+                className="p-1 text-slate-400 hover:text-slate-600"
+              >
+                <X size={16} />
+              </button>
+            </div>
+            
+            <div className="space-y-3">
+              <div>
+                <label className="block text-sm font-medium text-slate-700 mb-1">상태</label>
+                <select 
+                  value={filters.status} 
+                  onChange={(e) => setFilters({...filters, status: e.target.value})}
+                  className="w-full px-3 py-2 border border-slate-200 rounded-lg text-sm focus:ring-2 focus:ring-blue-500 bg-white"
+                >
+                  <option value="all">모든 상태</option>
+                  <option value="not-started">시작 전</option>
+                  <option value="in-progress">진행 중</option>
+                  <option value="completed">완료</option>
+                  <option value="on-hold">보류</option>
+                </select>
+              </div>
+              
+              <div>
+                <label className="block text-sm font-medium text-slate-700 mb-1">우선순위</label>
+                <select 
+                  value={filters.priority} 
+                  onChange={(e) => setFilters({...filters, priority: e.target.value})}
+                  className="w-full px-3 py-2 border border-slate-200 rounded-lg text-sm focus:ring-2 focus:ring-blue-500 bg-white"
+                >
+                  <option value="all">모든 우선순위</option>
+                  <option value="critical">긴급</option>
+                  <option value="high">높음</option>
+                  <option value="medium">보통</option>
+                  <option value="low">낮음</option>
+                </select>
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* 메인 콘텐츠 영역 */}
+      <div className="p-6">
+        {/* 빈 상태 처리 */}
+        {filteredProjects.length === 0 && (searchQuery || filters.status !== 'all' || filters.priority !== 'all') ? (
+          <div className="text-center py-20">
+            <div className="w-16 h-16 bg-slate-100 rounded-full flex items-center justify-center mx-auto mb-4">
+              <Search size={32} className="text-slate-400" />
+            </div>
+            <h3 className="text-lg font-semibold text-slate-900 mb-2">
+              {searchQuery ? '검색 결과가 없습니다' : '조건에 맞는 프로젝트가 없습니다'}
+            </h3>
+            <p className="text-slate-600 mb-6">
+              {searchQuery ? '다른 키워드로 검색해보세요.' : '다른 조건을 선택하거나 새 프로젝트를 추가해보세요.'}
+            </p>
+          </div>
+        ) : (
+          /* 뷰별 컨텐츠 렌더링 */
+          <>
+            {activeView === 'board' && (
+              <BoardView 
+                filteredProjects={filteredProjects}
+                setSelectedProject={setSelectedProject}
+              />
+            )}
+            {activeView === 'list' && (
+              <ListView 
+                filteredProjects={filteredProjects}
+                setSelectedProject={setSelectedProject}
+              />
+            )}
+            {activeView === 'timeline' && (
+              <TimelineView 
+                filteredProjects={filteredProjects}
+                updateTask={updateTask}
+              />
+            )}
+            {activeView === 'analytics' && (
+              <AnalyticsView 
+                analytics={analytics}
+                projects={projects}
+              />
+            )}
+          </>
+        )}
+      </div>
+        
+      {/* 모달들 */}
+      <ProjectModal 
+        showModal={showProjectModal}
+        onClose={() => setShowProjectModal(false)}
+        onCreateProject={handleCreateProject}
+      />
+
+      <ProjectDetailModal 
+        selectedProject={selectedProject}
+        setSelectedProject={setSelectedProject}
+        updateTask={updateTask}
+        setShowTaskModal={setShowTaskModal}
+      />
+
+      <TaskModal 
+        showTaskModal={showTaskModal}
+        setShowTaskModal={setShowTaskModal}
+        selectedProject={selectedProject}
+        onAddTask={addTask}
+      />
     </div>
   );
 }

--- a/src/pages/StudyManagement/index.js
+++ b/src/pages/StudyManagement/index.js
@@ -2,7 +2,8 @@ import { useState } from 'react';
 import {
   Plus, BookOpen, Trophy, Target,
   Clock, BarChart3, Timer, PieChart,
-  BookMarked
+  BookMarked, Search, TrendingUp,
+  CheckCircle, Calendar
 } from 'lucide-react';
 import StudyDashboard from '../../components/study/StudyDashboard';
 import SubjectManagement from '../../components/study/SubjectManagement';
@@ -38,6 +39,10 @@ export default function StudyManagementSystem() {
   const [toastMessage, setToastMessage] = useState('');
   const [toastType, setToastType] = useState('success');
 
+  // 검색 및 필터 상태 추가
+  const [searchQuery, setSearchQuery] = useState('');
+  const [filterStatus, setFilterStatus] = useState('전체');
+
   // 유틸리티 함수들
   const getProgress = (subject) => {
     return Math.round((subject.completedChapters / subject.totalChapters) * 100);
@@ -61,6 +66,14 @@ export default function StudyManagementSystem() {
 
   const getCurrentStreak = () => {
     return Math.max(...subjects.map(s => s.currentStreak));
+  };
+
+  // 통계 계산
+  const stats = {
+    total: subjects.length,
+    inProgress: subjects.filter(s => s.completedChapters > 0 && s.completedChapters < s.totalChapters).length,
+    completed: subjects.filter(s => s.completedChapters === s.totalChapters).length,
+    notStarted: subjects.filter(s => s.completedChapters === 0).length
   };
 
   // 이벤트 핸들러들
@@ -151,47 +164,92 @@ export default function StudyManagementSystem() {
   };
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-slate-50 via-blue-50 to-indigo-50">
-      {/* 간단한 헤더 */}
-      <div className="bg-white/80 backdrop-blur-xl border-b border-slate-200/60 sticky top-0 z-40 shadow-sm">
-        <div className="max-w mx-auto px-6 py-3">
+    <div className="min-h-screen bg-slate-50">
+      {/* 상단 헤더 바 (원서 관리와 동일한 구조) */}
+      <div className="bg-white border-b border-slate-200 sticky top-0 z-10">
+        <div className="px-6 py-4">
           <div className="flex items-center justify-between">
-            <div className="flex items-center gap-3">
-              <div className="p-2 bg-gradient-to-br from-emerald-500 to-teal-600 rounded-xl shadow-lg">
-              <BookOpen size={24} className="text-white" />
-            </div>
+            {/* 페이지 제목 */}
             <div>
-              <h1 className="text-xl font-bold bg-gradient-to-r from-slate-900 to-slate-600 bg-clip-text text-transparent">
-                학습 관리
-              </h1>
-                <p className="text-xs text-slate-600 mt-0.5">체계적인 학습으로 목표를 달성하세요!</p>
-              </div>
-          </div>
-          
-          <div className="flex items-center gap-3">
+              <h1 className="text-2xl font-bold text-slate-900">학습 관리</h1>
+              <p className="text-sm text-slate-600 mt-0.5">체계적인 학습으로 목표를 달성하세요</p>
+            </div>
+
+            {/* 우측 액션 버튼들 */}
+            <div className="flex items-center gap-3">
               <div className="flex items-center gap-2 bg-slate-50/80 backdrop-blur px-3 py-2 rounded-lg border border-slate-200/50">
-              <Trophy size={16} className="text-amber-500" />
+                <Trophy size={16} className="text-amber-500" />
                 <span className="text-xs text-slate-600">{getCurrentStreak()}일 연속</span>
               </div>
               <div className="flex items-center gap-2 bg-slate-50/80 backdrop-blur px-3 py-2 rounded-lg border border-slate-200/50">
                 <Clock size={16} className="text-blue-500" />
                 <span className="text-xs text-slate-600">{formatTime(getTotalStudyTime())}</span>
+              </div>
+              <button 
+                onClick={() => setShowAddForm(true)}
+                className="bg-slate-900 text-white px-4 py-2 rounded-md text-sm font-medium hover:bg-slate-800 transition-colors flex items-center gap-2"
+              >
+                <Plus size={16} />
+                새 과목
+              </button>
             </div>
-            <button 
-              onClick={() => setShowAddForm(true)}
-                className="px-4 py-2.5 bg-gradient-to-r from-blue-500 to-indigo-600 text-white rounded-xl shadow-lg hover:shadow-xl hover:from-blue-600 hover:to-indigo-700 transition-all duration-300 flex items-center gap-2 font-medium"
-            >
-              <Plus size={18} /> 새 과목 추가
-            </button>
+          </div>
+
+          {/* 통계 카드들 (원서 관리와 동일한 구조) */}
+          <div className="grid grid-cols-4 gap-4 mt-6">
+            <div className="bg-slate-50 rounded-lg p-4">
+              <div className="flex items-center gap-3">
+                <div className="p-2 bg-slate-100 rounded-lg">
+                  <BookOpen size={20} className="text-slate-600" />
+                </div>
+                <div>
+                  <div className="text-2xl font-bold text-slate-900">{stats.total}</div>
+                  <div className="text-sm text-slate-500">전체 과목</div>
+                </div>
+              </div>
+            </div>
+            <div className="bg-blue-50 rounded-lg p-4">
+              <div className="flex items-center gap-3">
+                <div className="p-2 bg-blue-100 rounded-lg">
+                  <TrendingUp size={20} className="text-blue-600" />
+                </div>
+                <div>
+                  <div className="text-2xl font-bold text-blue-900">{stats.inProgress}</div>
+                  <div className="text-sm text-blue-600">진행 중</div>
+                </div>
+              </div>
+            </div>
+            <div className="bg-emerald-50 rounded-lg p-4">
+              <div className="flex items-center gap-3">
+                <div className="p-2 bg-emerald-100 rounded-lg">
+                  <CheckCircle size={20} className="text-emerald-600" />
+                </div>
+                <div>
+                  <div className="text-2xl font-bold text-emerald-900">{stats.completed}</div>
+                  <div className="text-sm text-emerald-600">완료</div>
+                </div>
+              </div>
+            </div>
+            <div className="bg-orange-50 rounded-lg p-4">
+              <div className="flex items-center gap-3">
+                <div className="p-2 bg-orange-100 rounded-lg">
+                  <Calendar size={20} className="text-orange-600" />
+                </div>
+                <div>
+                  <div className="text-2xl font-bold text-orange-900">{stats.notStarted}</div>
+                  <div className="text-sm text-orange-600">예정</div>
+                </div>
+              </div>
+            </div>
           </div>
         </div>
       </div>
-      </div>
 
-      <div className="max-w-7xl mx-auto px-6 py-8">
-        {/* 탭 네비게이션 */}
-          <div className="mb-8">
-          <div className="flex items-center gap-1 bg-gray-200 p-1 rounded-xl w-fit">
+      {/* 컨트롤 바 (탭 + 검색/필터) */}
+      <div className="bg-white border-b border-slate-200 px-6 py-3">
+        <div className="flex items-center justify-between">
+          {/* 탭 네비게이션 */}
+          <div className="flex items-center gap-1 bg-gray-200 p-1 rounded-xl">
             {[
               { id: 'dashboard', name: '대시보드', icon: BarChart3 },
               { id: 'subjects', name: '과목 관리', icon: BookMarked },
@@ -215,9 +273,44 @@ export default function StudyManagementSystem() {
                 </button>
               );
             })}
-            </div>
-        </div>
+          </div>
 
+          {/* 검색 & 필터 (과목 관리 탭에서만 표시) */}
+          {activeTab === 'subjects' && (
+            <div className="flex items-center gap-3">
+              <div className="relative">
+                <Search size={16} className="absolute left-3 top-1/2 -translate-y-1/2 text-slate-400" />
+                <input
+                  type="text"
+                  placeholder="과목 검색..."
+                  value={searchQuery}
+                  onChange={(e) => setSearchQuery(e.target.value)}
+                  className="pl-9 pr-4 py-2 border border-slate-200 rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent w-48"
+                />
+              </div>
+              
+              <div className="flex items-center gap-2">
+                {['전체', '진행 중', '완료', '예정'].map(status => (
+                  <button
+                    key={status}
+                    onClick={() => setFilterStatus(status)}
+                    className={`px-3 py-1.5 rounded-md text-sm font-medium transition-colors ${
+                      filterStatus === status 
+                        ? 'bg-slate-900 text-white' 
+                        : 'text-slate-600 hover:text-slate-800 hover:bg-slate-100'
+                    }`}
+                  >
+                    {status}
+                  </button>
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* 메인 콘텐츠 영역 */}
+      <div className="p-6">
         {/* 탭별 컨텐츠 */}
         {activeTab === 'dashboard' && (
           <StudyDashboard
@@ -250,6 +343,8 @@ export default function StudyManagementSystem() {
             setShowGoalForm={setShowGoalForm}
             setShowAddForm={setShowAddForm}
             updateStudyTime={updateStudyTime}
+            searchQuery={searchQuery}
+            filterStatus={filterStatus}
           />
         )}
 
@@ -306,5 +401,4 @@ export default function StudyManagementSystem() {
       </Toast>
     </div>
   );
-} 
-        
+}

--- a/src/pages/TextbookDetail/index.js
+++ b/src/pages/TextbookDetail/index.js
@@ -1,8 +1,7 @@
 import Breadcrumb from '../../components/common/Breadcrumb';
-import WeeklyProgress from '../../components/common/WeeklyProgress';
 import WeeklyGoalsWidget from '../../components/plan/WeeklyGoalsWidget';
 import { useParams, useNavigate } from 'react-router-dom';
-import { Play, BarChart3, MoreHorizontal, Calendar, CheckCircle, Plus, Target, Clock, BookOpen, TrendingUp, Save, X, Settings } from 'lucide-react';
+import { Play, BarChart3, MoreHorizontal, Calendar, CheckCircle, Target, Clock, BookOpen, TrendingUp } from 'lucide-react';
 import { PdfThumbnail } from '../../utils/pdfAnalyzer';
 import { useState, useEffect } from 'react';
 
@@ -109,7 +108,7 @@ const TextbookDetailPage = () => {
   // 노트와 하이라이트 개수
   const notes = textbook.notes || [];
   const noteCount = notes.filter(n => n.content && n.content.trim() !== '').length;
-  const highlightCount = notes.filter(n => n.type === 'highlight' || (n.color && !n.content)).length;
+  // const highlightCount = notes.filter(n => n.type === 'highlight' || (n.color && !n.content)).length;
 
   // 제목을 간단하게 표시하는 함수
   const getShortTitle = (title) => {
@@ -157,30 +156,30 @@ const TextbookDetailPage = () => {
   const noteSummaries = getRecentNoteSummaries();
 
   // 주간 진도 계산
-  const getWeeklyProgress = () => {
-    const today = new Date();
-    const startOfWeek = new Date(today.setDate(today.getDate() - today.getDay()));
+  // const getWeeklyProgress = () => {
+  //   const today = new Date();
+  //   const startOfWeek = new Date(today.setDate(today.getDate() - today.getDay()));
     
-    const weekDays = [];
-    const completedDays = [];
+  //   const weekDays = [];
+  //   const completedDays = [];
     
-    for (let i = 0; i < 7; i++) {
-      const day = new Date(startOfWeek);
-      day.setDate(startOfWeek.getDate() + i);
-      const dayStr = day.toISOString().split('T')[0];
+  //   for (let i = 0; i < 7; i++) {
+  //     const day = new Date(startOfWeek);
+  //     day.setDate(startOfWeek.getDate() + i);
+  //     const dayStr = day.toISOString().split('T')[0];
       
-      weekDays.push(i);
+  //     weekDays.push(i);
       
-      const dayPlan = studyPlans.find(p => p.date === dayStr && p.completed);
-      if (dayPlan) {
-        completedDays.push(i);
-      }
-    }
+  //     const dayPlan = studyPlans.find(p => p.date === dayStr && p.completed);
+  //     if (dayPlan) {
+  //       completedDays.push(i);
+  //     }
+  //   }
     
-    return { selectedDays: weekDays, completedDays };
-  };
+  //   return { selectedDays: weekDays, completedDays };
+  // };
 
-  const weeklyProgress = getWeeklyProgress();
+  // const weeklyProgress = getWeeklyProgress();
 
   return (
     <div className="min-h-screen bg-slate-50">

--- a/src/pages/TextbookDetail/index.js
+++ b/src/pages/TextbookDetail/index.js
@@ -1,7 +1,8 @@
 import Breadcrumb from '../../components/common/Breadcrumb';
 import WeeklyProgress from '../../components/common/WeeklyProgress';
+import WeeklyGoalsWidget from '../../components/plan/WeeklyGoalsWidget';
 import { useParams, useNavigate } from 'react-router-dom';
-import { Play, Book, BarChart3, MoreHorizontal, Calendar, CheckCircle} from 'lucide-react';
+import { Play, BarChart3, MoreHorizontal, Calendar, CheckCircle, Plus, Target, Clock, BookOpen, TrendingUp, Save, X, Settings } from 'lucide-react';
 import { PdfThumbnail } from '../../utils/pdfAnalyzer';
 import { useState, useEffect } from 'react';
 
@@ -13,6 +14,9 @@ const TextbookDetailPage = () => {
   // 원서 데이터 상태
   const [textbook, setTextbook] = useState(null);
   const [isLoading, setIsLoading] = useState(true);
+
+  // 기존 학습 계획 데이터 (요일 정보 추가됨)
+  const [studyPlans, setStudyPlans] = useState([]);
 
   // 데이터 로드
   useEffect(() => {
@@ -27,6 +31,9 @@ const TextbookDetailPage = () => {
         }
 
         setTextbook(foundTextbook);
+        // 기존 학습 계획 로드 (plan 또는 weeklyGoals)
+        const plans = foundTextbook.plan || foundTextbook.weeklyGoals || [];
+        setStudyPlans(plans);
       } catch (error) {
         console.error('원서 데이터 로드 실패:', error);
         navigate('/textbook');
@@ -38,12 +45,34 @@ const TextbookDetailPage = () => {
     if (id) {
       loadTextbookData();
     }
-  }, [id, navigate]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [id, navigate]);
+
+  // 학습 계획 업데이트 (요일 정보 포함)
+  const updateStudyPlans = (updatedPlans) => {
+    try {
+      const books = JSON.parse(localStorage.getItem('textbooks') || '[]');
+      const bookIndex = books.findIndex(book => book.id === parseInt(id));
+      
+      if (bookIndex !== -1) {
+        books[bookIndex] = { 
+          ...books[bookIndex], 
+          plan: updatedPlans,
+          weeklyGoals: updatedPlans // 호환성 유지
+        };
+        localStorage.setItem('textbooks', JSON.stringify(books));
+        setTextbook(prev => ({ ...prev, plan: updatedPlans }));
+      }
+      
+      setStudyPlans(updatedPlans);
+    } catch (error) {
+      console.error('학습 계획 업데이트 실패:', error);
+    }
+  };
 
   // 로딩 중
   if (isLoading) {
     return (
-      <div className="min-h-screen bg-gray-50 flex items-center justify-center">
+      <div className="min-h-screen bg-slate-50 flex items-center justify-center">
         <div className="text-center">
           <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600 mx-auto mb-4"></div>
           <p className="text-lg font-medium text-gray-700">원서 정보 로딩 중...</p>
@@ -72,13 +101,12 @@ const TextbookDetailPage = () => {
     return `${mins}분`;
   };
 
-  // 학습 계획 통계 (향상된 계산)
-  const studyPlan = textbook.plan || [];
-  const completedChapters = studyPlan.filter(p => p.completed).length;
-  const totalChapters = studyPlan.length;
-  const todayPlan = studyPlan.find(p => p.date === new Date().toISOString().split('T')[0]);
+  // 학습 계획 통계
+  const completedChapters = studyPlans.filter(p => p.completed).length;
+  const totalChapters = studyPlans.length;
+  const todayPlan = studyPlans.find(p => p.date === new Date().toISOString().split('T')[0]);
 
-  // 노트와 하이라이트 개수 (정확한 계산)
+  // 노트와 하이라이트 개수
   const notes = textbook.notes || [];
   const noteCount = notes.filter(n => n.content && n.content.trim() !== '').length;
   const highlightCount = notes.filter(n => n.type === 'highlight' || (n.color && !n.content)).length;
@@ -86,42 +114,18 @@ const TextbookDetailPage = () => {
   // 제목을 간단하게 표시하는 함수
   const getShortTitle = (title) => {
     if (!title) return '';
-    
-    // 파일명에서 추출된 긴 제목을 간단하게 처리
-    // 예: "컴파일러-Alfred V. Aho, Monica S. Lam, Ravi Sethi, Jeffrey D. Ullman - Compilers - Principles, Techniques, and Tools (2006, Pearson_Addison Wesley) - libgen.li"
-    // → "컴파일러"로 표시
-    
-    // 첫 번째 하이픈이나 대시 이전의 부분만 사용
     const shortTitle = title.split(/[-–—]/)[0].trim();
-    
-    // 25자 이상이면 "..." 추가 (더 적절한 길이)
     if (shortTitle.length > 25) {
       return shortTitle.substring(0, 25) + '...';
     }
-    
     return shortTitle;
-  };
-
-  // 저자 정보도 간단하게 표시하는 함수
-  const getShortAuthor = (author) => {
-    if (!author) return '';
-    
-    // 저자가 여러 명인 경우 첫 번째 저자만 표시
-    const firstAuthor = author.split(',')[0].trim();
-    
-    // 20자 이상이면 "..." 추가 (더 적절한 길이)
-    if (firstAuthor.length > 20) {
-      return firstAuthor.substring(0, 20) + '...';
-    }
-    
-    return firstAuthor;
   };
 
   const handleStartStudy = () => {
     navigate(`/textbook/${id}/study`, { state: { textbookTitle: textbook.title } });
   };
 
-  // 최근 노트 요약 (실제 데이터 기반)
+  // 최근 노트 요약
   const getRecentNoteSummaries = () => {
     if (!notes || notes.length === 0) {
       return [
@@ -136,7 +140,6 @@ const TextbookDetailPage = () => {
       ];
     }
 
-    // 최근 2개의 노트만 표시
     return notes
       .filter(note => note.content && note.content.trim() !== '')
       .sort((a, b) => new Date(b.updatedAt || b.createdAt) - new Date(a.updatedAt || a.createdAt))
@@ -153,10 +156,10 @@ const TextbookDetailPage = () => {
 
   const noteSummaries = getRecentNoteSummaries();
 
-  // 주간 진도 계산 (실제 계획 기반)
+  // 주간 진도 계산
   const getWeeklyProgress = () => {
     const today = new Date();
-    const startOfWeek = new Date(today.setDate(today.getDate() - today.getDay())); // 일요일
+    const startOfWeek = new Date(today.setDate(today.getDate() - today.getDay()));
     
     const weekDays = [];
     const completedDays = [];
@@ -168,8 +171,7 @@ const TextbookDetailPage = () => {
       
       weekDays.push(i);
       
-      // 해당 날짜의 계획이 완료되었는지 확인
-      const dayPlan = studyPlan.find(p => p.date === dayStr && p.completed);
+      const dayPlan = studyPlans.find(p => p.date === dayStr && p.completed);
       if (dayPlan) {
         completedDays.push(i);
       }
@@ -181,266 +183,332 @@ const TextbookDetailPage = () => {
   const weeklyProgress = getWeeklyProgress();
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-slate-50 via-blue-50 to-indigo-50">
-      {/* 해더 */}
-      <div className="bg-white/95 backdrop-blur-xl border-b border-slate-200/60 sticky top-0 z-20 shadow-sm">
-        <div className="max-w mx-auto px-6 py-3 flex items-center justify-between">
-          <div className="flex items-center gap-3">
-            <div className="p-2 bg-gradient-to-br from-blue-500 to-purple-600 rounded-xl shadow-lg">
-              <Book size={24} className="text-white" />
-            </div>
-            <div>
-              <h1 className="text-xl font-bold bg-gradient-to-r from-slate-900 to-slate-600 bg-clip-text text-transparent">
-                원서 상세
-              </h1>
-              <p className="text-xs text-slate-600 mt-0.5">원서 학습 현황을 한눈에 확인하세요!</p>
-            </div>
-          </div>
-          
-          <div className="flex items-center gap-3">
-            <div className="flex items-center gap-2 bg-slate-50/80 backdrop-blur px-3 py-2 rounded-lg border border-slate-200/50">
-              <BarChart3 size={16} className="text-blue-500" />
-              <span className="text-xs text-slate-600">{progress}% 완료</span>
-            </div>
-            <button className="p-2.5 text-slate-600 hover:text-slate-800 hover:bg-slate-100 rounded-xl transition-all duration-200">
-              <MoreHorizontal size={18} />
-            </button>
-          </div>
-        </div>
-      </div>
-      <div className="max-w-7xl mx-auto px-6 py-8">
-        <Breadcrumb />
-        {/* 원서 정보 카드: 가장 위로 이동 */}
-        <div className="bg-white rounded-2xl shadow-sm border border-gray-100 overflow-hidden mb-8">
-          <div className="p-8">
-            <div className="flex items-start space-x-8">
-              <div className="relative">
-                {/* PDF 썸네일 컴포넌트 사용 */}
-                <PdfThumbnail 
-                  pdfId={textbook.pdfId || textbook.id.toString()} 
-                  width={192} 
-                  height={256}
-                  className="shadow-lg"
-                />
-                <div className="absolute -bottom-3 -right-3 w-12 h-12 bg-blue-600 rounded-full flex items-center justify-center text-white font-bold text-lg shadow-lg">
-                  {progress}%
-                </div>
-              </div>
-              <div className="flex-1 space-y-6">
+    <div className="min-h-screen bg-slate-50">
+      <div className="flex">
+        {/* 메인 콘텐츠 */}
+        <div className="flex-1">
+          {/* 상단 바 */}
+          <div className="bg-white border-b border-slate-200 sticky top-0 z-10">
+            <div className="px-6 py-4">
+              <div className="flex items-center justify-between">
+                {/* 페이지 제목 */}
                 <div>
-                  <h1 className="text-3xl font-bold text-gray-900 mb-2" title={textbook.title}>
-                    {getShortTitle(textbook.title)}
-                  </h1>
-                  <p className="text-xl text-gray-600 mb-4" title={textbook.author}>
-                    {getShortAuthor(textbook.author)}
-                  </p>
-                  <div className="flex items-center space-x-4 text-gray-500">
-                    <span>출판사: {textbook.publisher}</span>
-                    <span>•</span>
-                    <span>총 {textbook.totalPages}페이지</span>
-                    <span>•</span>
-                    <span>현재 {textbook.currentPage}페이지</span>
+                  <h1 className="text-2xl font-bold text-slate-900">{getShortTitle(textbook.title)}</h1>
+                  <div className='py-2 flex'>
+                    <Breadcrumb />
                   </div>
                 </div>
-                <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-                  <div className="bg-blue-50 rounded-lg p-4 text-center">
-                    <div className="text-2xl font-bold text-blue-600 mb-1">{progress}%</div>
-                    <div className="text-sm text-blue-700">진행률</div>
+
+                {/* 우측 액션 버튼들 */}
+                <div className="flex items-center gap-3">
+                  <div className="flex items-center gap-2 bg-slate-50 px-3 py-2 rounded-lg border border-slate-200">
+                    <BarChart3 size={16} className="text-blue-500" />
+                    <span className="text-xs text-slate-600">{progress}% 완료</span>
                   </div>
-                  <div className="bg-green-50 rounded-lg p-4 text-center">
-                    <div className="text-2xl font-bold text-green-600 mb-1">{noteCount}</div>
-                    <div className="text-sm text-green-700">노트</div>
-                  </div>
-                  <div className="bg-purple-50 rounded-lg p-4 text-center">
-                    <div className="text-2xl font-bold text-purple-600 mb-1">{formatTime(textbook.studyTime || 0)}</div>
-                    <div className="text-sm text-purple-700">학습 시간</div>
-                  </div>
-                  <div className="bg-orange-50 rounded-lg p-4 text-center">
-                    <div className="text-2xl font-bold text-orange-600 mb-1">{completedChapters}/{totalChapters}</div>
-                    <div className="text-sm text-orange-700">완료 챕터</div>
-                  </div>
-                </div>
-                <div className="flex items-center space-x-4">
                   <button
                     onClick={handleStartStudy}
-                    className="bg-blue-600 text-white px-8 py-3 rounded-xl font-semibold hover:bg-blue-700 transition-colors flex items-center space-x-2"
+                    className="bg-slate-900 text-white px-4 py-2 rounded-md text-sm font-medium hover:bg-slate-800 transition-colors flex items-center gap-2"
                   >
-                    <Play className="w-5 h-5" />
-                    <span>학습 시작하기</span>
+                    <Play size={16} />
+                    학습 시작
                   </button>
-                  <div className="text-sm text-gray-600">
-                    목표 완료일: {textbook.targetDate}
+                  <button className="p-2.5 text-slate-600 hover:text-slate-800 hover:bg-slate-100 rounded-xl transition-all duration-200">
+                    <MoreHorizontal size={18} />
+                  </button>
+                </div>
+              </div>
+
+              {/* 통계 카드들 */}
+              <div className="grid grid-cols-4 gap-4 mt-6">
+                <div className="bg-slate-50 rounded-lg p-4">
+                  <div className="flex items-center gap-3">
+                    <div className="p-2 bg-slate-100 rounded-lg">
+                      <BookOpen size={20} className="text-slate-600" />
+                    </div>
+                    <div>
+                      <div className="text-2xl font-bold text-slate-900">{progress}%</div>
+                      <div className="text-sm text-slate-500">진행률</div>
+                    </div>
+                  </div>
+                </div>
+                <div className="bg-blue-50 rounded-lg p-4">
+                  <div className="flex items-center gap-3">
+                    <div className="p-2 bg-blue-100 rounded-lg">
+                      <TrendingUp size={20} className="text-blue-600" />
+                    </div>
+                    <div>
+                      <div className="text-2xl font-bold text-blue-900">{noteCount}</div>
+                      <div className="text-sm text-blue-600">작성 노트</div>
+                    </div>
+                  </div>
+                </div>
+                <div className="bg-emerald-50 rounded-lg p-4">
+                  <div className="flex items-center gap-3">
+                    <div className="p-2 bg-emerald-100 rounded-lg">
+                      <Clock size={20} className="text-emerald-600" />
+                    </div>
+                    <div>
+                      <div className="text-2xl font-bold text-emerald-900">{formatTime(textbook.studyTime || 0)}</div>
+                      <div className="text-sm text-emerald-600">학습 시간</div>
+                    </div>
+                  </div>
+                </div>
+                <div className="bg-orange-50 rounded-lg p-4">
+                  <div className="flex items-center gap-3">
+                    <div className="p-2 bg-orange-100 rounded-lg">
+                      <Target size={20} className="text-orange-600" />
+                    </div>
+                    <div>
+                      <div className="text-2xl font-bold text-orange-900">{completedChapters}/{totalChapters}</div>
+                      <div className="text-sm text-orange-600">완료 챕터</div>
+                    </div>
                   </div>
                 </div>
               </div>
             </div>
           </div>
-        </div>
-        
-        {/* 3분할 카드형 섹션 */}
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-8 mb-8">
-          {/* 노트 요약 카드 */}
-          <div className="bg-white rounded-xl p-6 shadow-sm border border-gray-100 flex flex-col gap-4">
-            <h3 className="text-lg font-semibold text-blue-900 mb-2">최근 노트</h3>
-            {noteSummaries.map((note, idx) => (
-              <div key={idx} className={`p-3 rounded-lg mb-2 ${note.isEmpty ? 'bg-gray-50 border-2 border-dashed border-gray-200' : 'bg-blue-50'}`}>
-                <h4 className={`font-semibold mb-1 ${note.isEmpty ? 'text-gray-500' : 'text-blue-800'}`}>
-                  {note.title}
-                </h4>
-                <p className={`text-sm mb-1 ${note.isEmpty ? 'text-gray-400' : 'text-blue-700'}`}>
-                  {note.summary}
-                </p>
-                {!note.isEmpty && (
-                  <div className="flex items-center justify-between mt-1">
-                    <span className="text-xs text-blue-600">{note.chapter}</span>
-                    <span className="text-xs text-blue-400">{note.date}</span>
+
+          {/* 메인 콘텐츠 영역 */}
+          <div className="p-4">
+            
+            {/* 원서 정보 카드 */}
+            <div className="bg-white rounded-2xl shadow-sm border border-gray-100 overflow-hidden mb-8 mt-6">
+              <div className="p-8">
+                <div className="flex items-start space-x-8">
+                  <div className="relative">
+                    <PdfThumbnail 
+                      pdfId={textbook.pdfId || textbook.id.toString()} 
+                      width={192} 
+                      height={256}
+                      className="shadow-lg"
+                    />
+                    <div className="absolute -bottom-3 -right-3 w-12 h-12 bg-blue-600 rounded-full flex items-center justify-center text-white font-bold text-lg shadow-lg">
+                      {progress}%
+                    </div>
                   </div>
-                )}
-              </div>
-            ))}
-            {noteCount > 2 && (
-              <div className="text-center">
-                <button 
-                  onClick={() => navigate(`/textbook/${id}/study?view=notes`)}
-                  className="text-sm text-blue-600 hover:text-blue-800 font-medium"
-                >
-                  전체 노트 보기 ({noteCount}개)
-                </button>
-              </div>
-            )}
-          </div>
-          
-          {/* 학습 현황 카드 */}
-          <div className="bg-white rounded-xl p-6 shadow-sm border border-gray-100 flex flex-col gap-4">
-            <h3 className="text-lg font-semibold text-green-900 mb-2">학습 현황</h3>
-            <div className="flex flex-col gap-2">
-              <div className="flex items-center gap-2">
-                <span className="text-green-700 font-bold text-2xl">{progress}%</span>
-                <span className="text-gray-600 text-sm">진도율</span>
-              </div>
-              <div className="w-full h-2 bg-green-200 rounded-full overflow-hidden mb-2">
-                <div className="h-full bg-green-500 rounded-full transition-all duration-500" style={{ width: `${progress}%` }}></div>
-              </div>
-              <div className="flex items-center gap-4 text-sm text-gray-700">
-                <span>현재 페이지 <span className="font-bold text-green-700">{textbook.currentPage}</span> / {textbook.totalPages}</span>
-              </div>
-              <div className="flex items-center gap-4 text-xs text-gray-500">
-                <span>시작일: {textbook.startDate}</span>
-                <span>목표 완료일: {textbook.targetDate}</span>
-              </div>
-              <div className="flex items-center gap-4 text-xs text-gray-500">
-                <span>학습 목적: {textbook.purpose}</span>
-                <span>학습 강도: {textbook.intensity}</span>
-              </div>
-              {todayPlan && (
-                <div className="bg-green-50 rounded-lg p-3 mt-2">
-                  <div className="flex items-center gap-2 mb-1">
-                    <Calendar className="w-4 h-4 text-green-600" />
-                    <span className="text-sm font-medium text-green-800">오늘의 계획</span>
+                  <div className="flex-1 space-y-6">
+                    <div>
+                      <h1 className="text-3xl font-bold text-gray-900 mb-2" title={textbook.title}>
+                        {textbook.title}
+                      </h1>
+                      <p className="text-xl text-gray-600 mb-4" title={textbook.author}>
+                        {textbook.author}
+                      </p>
+                      <div className="flex items-center space-x-4 text-gray-500">
+                        <span>출판사: {textbook.publisher}</span>
+                        <span>•</span>
+                        <span>총 {textbook.totalPages}페이지</span>
+                        <span>•</span>
+                        <span>현재 {textbook.currentPage}페이지</span>
+                      </div>
+                      <div className="text-sm text-gray-600 py-1">
+                        목표 완료일: {textbook.targetDate}
+                      </div>
+                    </div>
                   </div>
-                  <p className="text-sm text-green-700">{todayPlan.chapter}</p>
-                  {todayPlan.completed && (
-                    <div className="flex items-center gap-1 mt-1">
-                      <CheckCircle className="w-3 h-3 text-green-600" />
-                      <span className="text-xs text-green-600">완료됨</span>
+                </div>
+              </div>
+            </div>
+            
+            {/* 4분할 카드형 섹션 */}
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 mb-8">
+              {/* 최근 노트 카드 */}
+              <div className="group bg-gradient-to-br from-blue-50 to-indigo-50 rounded-2xl p-6 border border-blue-100 hover:border-blue-200 transition-all duration-300 hover:shadow-lg hover:shadow-blue-100/50 hover:-translate-y-1">
+                <div className="flex items-center justify-between mb-4">
+                  <div className="flex items-center gap-2">
+                    <div className="p-2 bg-blue-100 rounded-xl group-hover:bg-blue-200 transition-colors">
+                      <BookOpen className="w-5 h-5 text-blue-600" />
+                    </div>
+                    <h3 className="text-lg font-bold text-blue-900">최근 노트</h3>
+                  </div>
+                  <div className="px-2 py-1 bg-white/80 rounded-full text-xs font-semibold text-blue-700">
+                    {noteCount}개
+                  </div>
+                </div>
+                
+                <div className="space-y-3">
+                  {noteSummaries.slice(0, 1).map((note, idx) => (
+                    <div key={idx} className={`p-4 rounded-xl transition-all duration-200 ${
+                      note.isEmpty 
+                        ? 'bg-white/60 border-2 border-dashed border-blue-200' 
+                        : 'bg-white/80 backdrop-blur-sm hover:bg-white/90'
+                    }`}>
+                      <h4 className={`font-bold mb-2 text-sm line-clamp-1 ${
+                        note.isEmpty ? 'text-blue-400' : 'text-blue-900'
+                      }`}>
+                        {note.title}
+                      </h4>
+                      <p className={`text-xs mb-3 leading-relaxed line-clamp-3 ${
+                        note.isEmpty ? 'text-blue-300' : 'text-blue-700'
+                      }`}>
+                        {note.summary.length > 80 ? note.summary.substring(0, 80) + '...' : note.summary}
+                      </p>
+                      {!note.isEmpty && (
+                        <div className="flex items-center justify-between">
+                          <span className="px-2 py-1 bg-blue-100 rounded-full text-xs font-medium text-blue-700">
+                            {note.chapter}
+                          </span>
+                          <span className="text-xs text-blue-500 font-medium">{note.date}</span>
+                        </div>
+                      )}
+                    </div>
+                  ))}
+                  
+                  {noteCount > 1 && (
+                    <button 
+                      onClick={() => navigate(`/textbook/${id}/study?view=notes`)}
+                      className="w-full mt-3 py-2 text-sm font-semibold text-blue-600 hover:text-blue-800 bg-white/60 hover:bg-white/80 rounded-xl transition-all duration-200"
+                    >
+                      전체 {noteCount}개 노트 보기 →
+                    </button>
+                  )}
+                </div>
+              </div>
+              
+              {/* 학습 현황 카드 */}
+              <div className="group bg-gradient-to-br from-emerald-50 to-green-50 rounded-2xl p-6 border border-emerald-100 hover:border-emerald-200 transition-all duration-300 hover:shadow-lg hover:shadow-emerald-100/50 hover:-translate-y-1">
+                <div className="flex items-center justify-between mb-4">
+                  <div className="flex items-center gap-2">
+                    <div className="p-2 bg-emerald-100 rounded-xl group-hover:bg-emerald-200 transition-colors">
+                      <TrendingUp className="w-5 h-5 text-emerald-600" />
+                    </div>
+                    <h3 className="text-lg font-bold text-emerald-900">학습 현황</h3>
+                  </div>
+                  <div className="px-3 py-2 bg-white/80 rounded-full">
+                    <span className="text-2xl font-bold text-emerald-700">{progress}%</span>
+                  </div>
+                </div>
+                
+                <div className="space-y-4">
+                  <div className="relative">
+                    <div className="flex justify-between mb-2">
+                      <span className="text-sm font-medium text-emerald-700">전체 진도율</span>
+                      <span className="text-sm font-bold text-emerald-800">{textbook.currentPage}p / {textbook.totalPages}p</span>
+                    </div>
+                    <div className="w-full h-3 bg-emerald-200 rounded-full overflow-hidden">
+                      <div className="h-full bg-gradient-to-r from-emerald-400 to-emerald-500 rounded-full transition-all duration-700 shadow-sm" 
+                           style={{ width: `${progress}%` }}>
+                      </div>
+                    </div>
+                  </div>
+                  
+                  <div className="bg-white/70 backdrop-blur-sm rounded-xl p-4">
+                    <div className="grid grid-cols-2 gap-4">
+                      <div className="text-center">
+                        <div className="text-2xl font-bold text-emerald-700">{formatTime(textbook.studyTime || 0).split(' ')[0]}</div>
+                        <div className="text-xs text-emerald-600 font-medium">학습시간</div>
+                      </div>
+                      <div className="text-center">
+                        <div className="text-2xl font-bold text-emerald-700">{Math.ceil((textbook.totalPages - textbook.currentPage) / 20) || 0}</div>
+                        <div className="text-xs text-emerald-600 font-medium">예상 남은일</div>
+                      </div>
+                    </div>
+                  </div>
+
+                  {todayPlan && (
+                    <div className="bg-emerald-100/80 backdrop-blur-sm rounded-xl p-3">
+                      <div className="flex items-center gap-2 mb-2">
+                        <Calendar className="w-4 h-4 text-emerald-600" />
+                        <span className="text-sm font-bold text-emerald-800">오늘의 목표</span>
+                      </div>
+                      <p className="text-xs text-emerald-700 font-medium">{todayPlan.chapter}</p>
+                      {todayPlan.completed && (
+                        <div className="flex items-center gap-2 mt-2 px-2 py-1 bg-emerald-200 rounded-lg">
+                          <CheckCircle className="w-3 h-3 text-emerald-600" />
+                          <span className="text-xs font-semibold text-emerald-700">완료!</span>
+                        </div>
+                      )}
                     </div>
                   )}
                 </div>
-              )}
-            </div>
-          </div>
-          
-          {/* 학습 계획 현황 카드 */}
-          <div className="bg-white rounded-xl p-6 shadow-sm border border-gray-100 flex flex-col gap-4">
-            <h3 className="text-lg font-semibold text-purple-900 mb-2">학습 계획</h3>
-            <div className="flex flex-col gap-2">
-              <div className="flex items-center gap-2">
-                <span className="text-purple-700 font-bold text-2xl">{completedChapters}</span>
-                <span className="text-gray-600 text-sm">/ {totalChapters} 챕터</span>
               </div>
               
-              {totalChapters > 0 && (
-                <div className="w-full h-2 bg-purple-200 rounded-full overflow-hidden mb-2">
-                  <div 
-                    className="h-full bg-purple-500 rounded-full transition-all duration-500" 
-                    style={{ width: `${(completedChapters / totalChapters) * 100}%` }}
-                  ></div>
+              {/* 학습 계획 현황 카드 */}
+              <div className="group bg-gradient-to-br from-violet-50 to-purple-50 rounded-2xl p-6 border border-violet-100 hover:border-violet-200 transition-all duration-300 hover:shadow-lg hover:shadow-violet-100/50 hover:-translate-y-1">
+                <div className="flex items-center justify-between mb-4">
+                  <div className="flex items-center gap-2">
+                    <div className="p-2 bg-violet-100 rounded-xl group-hover:bg-violet-200 transition-colors">
+                      <Target className="w-5 h-5 text-violet-600" />
+                    </div>
+                    <h3 className="text-lg font-bold text-violet-900">학습 계획</h3>
+                  </div>
+                  <div className="px-3 py-1 bg-white/80 rounded-full text-sm font-bold text-violet-700">
+                    {completedChapters}/{totalChapters}
+                  </div>
                 </div>
-              )}
-              
-              <div className="flex items-center gap-4 text-sm text-gray-700">
-                <span>완료: <span className="font-bold text-purple-700">{completedChapters}</span></span>
-                <span>남은 계획: <span className="font-bold text-purple-700">{totalChapters - completedChapters}</span></span>
-              </div>
-              
-              {studyPlan.length > 0 && (
-                <div className="bg-purple-50 rounded-lg p-3 mt-2">
-                  <div className="text-xs text-purple-700 mb-1">다음 학습 계획</div>
-                  {(() => {
-                    const nextPlan = studyPlan.find(p => !p.completed);
-                    if (nextPlan) {
-                      return (
-                        <div>
-                          <p className="text-sm font-medium text-purple-800">{nextPlan.chapter}</p>
-                          <p className="text-xs text-purple-600 mt-1">목표일: {nextPlan.date}</p>
+                
+                <div className="space-y-4">
+                  {totalChapters > 0 && (
+                    <div className="relative">
+                      <div className="flex justify-between mb-2">
+                        <span className="text-sm font-medium text-violet-700">완료율</span>
+                        <span className="text-sm font-bold text-violet-800">
+                          {Math.round((completedChapters / totalChapters) * 100)}%
+                        </span>
+                      </div>
+                      <div className="w-full h-3 bg-violet-200 rounded-full overflow-hidden">
+                        <div className="h-full bg-gradient-to-r from-violet-400 to-violet-500 rounded-full transition-all duration-700 shadow-sm" 
+                             style={{ width: `${(completedChapters / totalChapters) * 100}%` }}>
                         </div>
-                      );
-                    } else {
-                      return (
-                        <div className="flex items-center gap-1">
-                          <CheckCircle className="w-4 h-4 text-green-600" />
-                          <span className="text-sm text-green-700">모든 계획 완료!</span>
-                        </div>
-                      );
-                    }
-                  })()}
+                      </div>
+                    </div>
+                  )}
+                  
+                  <div className="bg-white/70 backdrop-blur-sm rounded-xl p-4">
+                    <div className="grid grid-cols-2 gap-4 text-center">
+                      <div>
+                        <div className="text-2xl font-bold text-violet-700">{completedChapters}</div>
+                        <div className="text-xs text-violet-600 font-medium">완료</div>
+                      </div>
+                      <div>
+                        <div className="text-2xl font-bold text-violet-700">{totalChapters - completedChapters}</div>
+                        <div className="text-xs text-violet-600 font-medium">남은 계획</div>
+                      </div>
+                    </div>
+                  </div>
+
+                  {studyPlans.length > 0 && (
+                    <div className="bg-violet-100/80 backdrop-blur-sm rounded-xl p-3">
+                      <div className="text-xs font-bold text-violet-700 mb-2">다음 계획</div>
+                      {(() => {
+                        const nextPlan = studyPlans.find(p => !p.completed);
+                        if (nextPlan) {
+                          return (
+                            <div className="space-y-1">
+                              <p className="text-sm font-bold text-violet-800 line-clamp-1">
+                                {nextPlan.title || nextPlan.chapter}
+                              </p>
+                              <div className="flex items-center gap-2">
+                                <span className="px-2 py-0.5 bg-violet-200 rounded-full text-xs font-medium text-violet-700">
+                                  {nextPlan.week ? `${nextPlan.week}주차` : nextPlan.date}
+                                </span>
+                              </div>
+                            </div>
+                          );
+                        } else if (studyPlans.length > 0) {
+                          return (
+                            <div className="flex items-center gap-2 px-2 py-1 bg-emerald-200 rounded-lg">
+                              <CheckCircle className="w-4 h-4 text-emerald-600" />
+                              <span className="text-sm font-bold text-emerald-700">모든 계획 완료!</span>
+                            </div>
+                          );
+                        } else {
+                          return (
+                            <span className="text-sm text-violet-600">아직 계획이 없습니다</span>
+                          );
+                        }
+                      })()}
+                    </div>
+                  )}
                 </div>
-              )}
-            </div>
-          </div>
-        </div>
-        
-        {/* 학습 현황 및 목표: 2분할로 다시 추가 */}
-        <div className="grid grid-cols-1 lg:grid-cols-2 gap-8 mb-8">
-          <WeeklyProgress 
-            selectedDays={weeklyProgress.selectedDays}
-            completedDays={weeklyProgress.completedDays}
-          />
-          <div className="bg-white rounded-xl p-6 shadow-sm border border-gray-100">
-            <h3 className="text-lg font-semibold text-gray-900 mb-4">학습 목표 및 통계</h3>
-            <div className="space-y-4">
-              <div className="flex items-center justify-between">
-                <span className="text-gray-700">목표 완료일</span>
-                <span className="font-semibold text-blue-600">{textbook.targetDate}</span>
               </div>
-              <div className="flex items-center justify-between">
-                <span className="text-gray-700">학습 강도</span>
-                <span className="font-semibold">{textbook.intensity}</span>
-              </div>
-              <div className="flex items-center justify-between">
-                <span className="text-gray-700">총 학습 시간</span>
-                <span className="font-semibold">{formatTime(textbook.studyTime || 0)}</span>
-              </div>
-              <div className="flex items-center justify-between">
-                <span className="text-gray-700">학습 목적</span>
-                <span className="font-semibold">{textbook.purpose}</span>
-              </div>
-              <div className="flex items-center justify-between">
-                <span className="text-gray-700">작성한 노트</span>
-                <span className="font-semibold text-green-600">{noteCount}개</span>
-              </div>
-              <div className="flex items-center justify-between">
-                <span className="text-gray-700">하이라이트</span>
-                <span className="font-semibold text-yellow-600">{highlightCount}개</span>
-              </div>
-              {textbook.lastStudiedAt && (
-                <div className="flex items-center justify-between">
-                  <span className="text-gray-700">마지막 학습</span>
-                  <span className="font-semibold text-gray-600">
-                    {new Date(textbook.lastStudiedAt).toLocaleDateString('ko-KR')}
-                  </span>
-                </div>
-              )}
+              
+              {/* 주간 학습 목표 카드 */}
+              <WeeklyGoalsWidget
+                studyPlans={studyPlans}
+                onStudyPlansUpdate={updateStudyPlans}
+                className="group bg-gradient-to-br from-amber-50 to-orange-50 rounded-2xl border border-amber-100 hover:border-amber-200 transition-all duration-300 hover:shadow-lg hover:shadow-amber-100/50 hover:-translate-y-1"
+              />
             </div>
           </div>
         </div>

--- a/src/pages/TextbookManagement/AddTextbook.js
+++ b/src/pages/TextbookManagement/AddTextbook.js
@@ -1,6 +1,6 @@
 import { useState, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { ArrowLeft, Book, Target, Brain, Upload, FileText, Loader2, CheckCircle, AlertCircle } from 'lucide-react';
+import { ArrowLeft, Book, Target, Brain, Upload, FileText, Loader2, CheckCircle, AlertCircle, Plus } from 'lucide-react';
 import Button from '../../components/common/Button';
 import FileUpload from '../../components/common/FileUpload';
 import AIPlanGenerator from '../../components/plan/AIPlanGenerator';
@@ -222,8 +222,6 @@ export default function AddTextbook() {
     // PDF 분석 시작
     await analyzePDFFile(file);
   }, [analyzePDFFile]);
-
-  
 
   // 파일명에서 정보 추출 (fallback)
   const extractInfoFromFileName = (fileName) => {
@@ -491,412 +489,433 @@ export default function AddTextbook() {
   };
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-gray-50 to-blue-50">
-      {/* 헤더 */}
-      <div className="w-full bg-white shadow-sm border-b border-gray-200 sticky top-0 z-10">
-        <div className="max-w mx-auto px-4 py-2 flex items-center">
-          <div className="flex items-center gap-4">
-            <button
-              onClick={() => navigate('/textbook')}
-              className="p-2 text-gray-500 hover:text-gray-700 hover:bg-gray-100 rounded-xl transition-all duration-300"
-            >
-              <ArrowLeft className="w-5 h-5" />
-            </button>
-            <div>
-              <h1 className="text-2xl font-bold text-gray-900">새 원서 추가</h1>
-              <p className="text-sm text-gray-600">단계별로 원서 정보를 입력하세요</p>
-            </div>
-          </div>
-        </div>
-      </div>
-
-      {/* 진행 단계 표시 */}
-      <div className="max-w-4xl mx-auto px-6 py-8">
-        <div className="bg-white/80 backdrop-blur-sm rounded-2xl p-6 mb-8 shadow-lg border border-white/20">
-          <div className="flex items-center justify-between">
-            <div className="flex items-center gap-4">
-              <div className={`w-10 h-10 rounded-full flex items-center justify-center text-sm font-bold transition-all duration-300 ${
-                currentStep >= 1 ? 'bg-gradient-to-r from-blue-600 to-indigo-600 text-white shadow-lg' : 'bg-gray-200 text-gray-500'
-              }`}>
-                1
-              </div>
-              <span className={`text-sm font-medium transition-colors ${currentStep >= 1 ? 'text-blue-600' : 'text-gray-500'}`}>
-                기본 정보
-              </span>
-            </div>
-            <div className="flex-1 h-1 bg-gray-200 rounded-full mx-6 relative">
-              <div className={`h-full bg-gradient-to-r from-blue-600 to-indigo-600 rounded-full transition-all duration-500 ${
-                currentStep >= 2 ? 'w-full' : 'w-0'
-              }`}></div>
-            </div>
-            <div className="flex items-center gap-4">
-              <div className={`w-10 h-10 rounded-full flex items-center justify-center text-sm font-bold transition-all duration-300 ${
-                currentStep >= 2 ? 'bg-gradient-to-r from-blue-600 to-indigo-600 text-white shadow-lg' : 'bg-gray-200 text-gray-500'
-              }`}>
-                2
-              </div>
-              <span className={`text-sm font-medium transition-colors ${currentStep >= 2 ? 'text-blue-600' : 'text-gray-500'}`}>
-                학습 계획
-              </span>
-            </div>
-          </div>
-        </div>
-
-        {/* 단계별 컨텐츠 */}
-        <div className="bg-white/80 backdrop-blur-sm rounded-2xl shadow-xl border border-white/20 overflow-hidden">
-          {currentStep === 1 && (
-            <div className="p-8 space-y-8">
-              <div className="flex items-center gap-3 mb-8">
-                <div className="w-12 h-12 bg-gradient-to-r from-blue-500 to-indigo-600 rounded-xl flex items-center justify-center text-white">
-                  <Book className="w-6 h-6" />
-                </div>
-                <div>
-                  <h2 className="text-2xl font-bold text-gray-900">기본 정보 입력</h2>
-                  <p className="text-gray-600">PDF 파일을 업로드하면 자동으로 정보를 추출합니다</p>
-                </div>
-              </div>
-
-              {/* 파일 업로드 */}
-              <div className="space-y-3">
-                <label className="block text-sm font-semibold text-gray-700">📁 전공 원서 파일 *</label>
-                <div className="border-2 border-dashed border-gray-300 rounded-2xl p-8 text-center hover:border-blue-400 transition-colors">
-                  <div className="flex flex-col items-center space-y-4">
-                    <div className="w-16 h-16 bg-blue-50 rounded-full flex items-center justify-center">
-                      <Upload className="w-8 h-8 text-blue-600" />
-                    </div>
-                    <div>
-                      <FileUpload
-                        onFileChange={handleFileChange}
-                        accept="application/pdf"
-                        label="PDF 파일을 드래그하거나 클릭하여 업로드하세요"
-                        disabled={isAnalyzing}
-                      />
-                      <p className="text-xs text-gray-500 mt-2">최대 100MB까지 업로드 가능</p>
-                    </div>
+    <div className="min-h-screen bg-slate-50">
+      <div className="flex">
+        {/* 메인 콘텐츠 */}
+        <div className="flex-1">
+          {/* 상단 바 */}
+          <div className="bg-white border-b border-slate-200 sticky top-0 z-10">
+            <div className="px-6 py-4">
+              <div className="flex items-center justify-between">
+                {/* 페이지 제목 */}
+                <div className="flex items-center gap-4">
+                  <button
+                    onClick={() => navigate('/textbook')}
+                    className="p-2 text-slate-500 hover:text-slate-700 hover:bg-slate-100 rounded-xl transition-all duration-300"
+                  >
+                    <ArrowLeft className="w-5 h-5" />
+                  </button>
+                  <div>
+                    <h1 className="text-2xl font-bold text-slate-900">새 원서 추가</h1>
+                    <p className="text-sm text-slate-600 mt-0.5">단계별로 원서 정보를 입력하세요</p>
                   </div>
                 </div>
-                
-                {/* 분석 상태 표시 */}
-                <AnalysisStatus />
-              </div>
 
-              {/* 원서 정보 */}
-              <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-                <div className="space-y-3">
-                  <label className="block text-sm font-semibold text-gray-700">📖 원서 제목 *</label>
-                  <input
-                    type="text"
-                    value={formData.title}
-                    onChange={(e) => setFormData(prev => ({ ...prev, title: e.target.value }))}
-                    className="w-full border border-gray-300 rounded-xl px-4 py-3 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all duration-300"
-                    placeholder="예: Operating Systems: Three Easy Pieces"
-                    disabled={isAnalyzing}
-                  />
-                  {analysisComplete && formData.title && (
-                    <p className="text-xs text-green-600">✓ PDF에서 자동 추출됨</p>
-                  )}
-                </div>
-                
-                <div className="space-y-3">
-                  <label className="block text-sm font-semibold text-gray-700">✍️ 저자</label>
-                  <input
-                    type="text"
-                    value={formData.author}
-                    onChange={(e) => setFormData(prev => ({ ...prev, author: e.target.value }))}
-                    className="w-full border border-gray-300 rounded-xl px-4 py-3 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all duration-300"
-                    placeholder="예: Remzi H. Arpaci-Dusseau"
-                    disabled={isAnalyzing}
-                  />
-                  {analysisComplete && formData.author && (
-                    <p className="text-xs text-green-600">✓ PDF에서 자동 추출됨</p>
-                  )}
-                </div>
-                
-                <div className="space-y-3">
-                  <label className="block text-sm font-semibold text-gray-700">🏢 출판사</label>
-                  <input
-                    type="text"
-                    value={formData.publisher}
-                    onChange={(e) => setFormData(prev => ({ ...prev, publisher: e.target.value }))}
-                    className="w-full border border-gray-300 rounded-xl px-4 py-3 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all duration-300"
-                    placeholder="예: MIT Press"
-                    disabled={isAnalyzing}
-                  />
-                  {analysisComplete && formData.publisher && (
-                    <p className="text-xs text-green-600">✓ PDF에서 자동 추출됨</p>
-                  )}
-                </div>
-                
-                <div className="space-y-3">
-                  <label className="block text-sm font-semibold text-gray-700">📄 총 페이지 수 *</label>
-                  <input
-                    type="number"
-                    value={formData.totalPages}
-                    onChange={(e) => setFormData(prev => ({ ...prev, totalPages: e.target.value }))}
-                    className="w-full border border-gray-300 rounded-xl px-4 py-3 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all duration-300"
-                    placeholder="예: 400"
-                    disabled={isAnalyzing}
-                  />
-                  {analysisComplete && formData.totalPages && (
-                    <p className="text-xs text-green-600">✓ PDF에서 자동 추출됨</p>
-                  )}
+                {/* 우측 액션 버튼들 */}
+                <div className="flex items-center gap-3">
+                  <Button 
+                    onClick={() => navigate('/textbook')}
+                    variant="secondary"
+                    className="px-4 py-2 rounded-md text-sm font-medium transition-colors"
+                  >
+                    취소
+                  </Button>
                 </div>
               </div>
 
-              {/* 과목/주제 (추가 정보) */}
-              {formData.subject && (
-                <div className="space-y-3">
-                  <label className="block text-sm font-semibold text-gray-700">📚 과목/주제</label>
-                  <input
-                    type="text"
-                    value={formData.subject}
-                    onChange={(e) => setFormData(prev => ({ ...prev, subject: e.target.value }))}
-                    className="w-full border border-gray-300 rounded-xl px-4 py-3 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all duration-300"
-                    placeholder="예: Computer Science, Operating Systems"
-                    disabled={isAnalyzing}
-                  />
-                  <p className="text-xs text-green-600">✓ PDF에서 자동 추출됨</p>
+              {/* 진행 단계 표시 */}
+              <div className="mt-6">
+                <div className="flex items-center justify-between">
+                  <div className="flex items-center gap-4">
+                    <div className={`w-10 h-10 rounded-full flex items-center justify-center text-sm font-bold transition-all duration-300 ${
+                      currentStep >= 1 ? 'bg-slate-900 text-white shadow-lg' : 'bg-slate-200 text-slate-500'
+                    }`}>
+                      1
+                    </div>
+                    <span className={`text-sm font-medium transition-colors ${currentStep >= 1 ? 'text-slate-900' : 'text-slate-500'}`}>
+                      기본 정보
+                    </span>
+                  </div>
+                  <div className="flex-1 h-1 bg-slate-200 rounded-full mx-6 relative">
+                    <div className={`h-full bg-slate-900 rounded-full transition-all duration-500 ${
+                      currentStep >= 2 ? 'w-full' : 'w-0'
+                    }`}></div>
+                  </div>
+                  <div className="flex items-center gap-4">
+                    <div className={`w-10 h-10 rounded-full flex items-center justify-center text-sm font-bold transition-all duration-300 ${
+                      currentStep >= 2 ? 'bg-slate-900 text-white shadow-lg' : 'bg-slate-200 text-slate-500'
+                    }`}>
+                      2
+                    </div>
+                    <span className={`text-sm font-medium transition-colors ${currentStep >= 2 ? 'text-slate-900' : 'text-slate-500'}`}>
+                      학습 계획
+                    </span>
+                  </div>
                 </div>
-              )}
+              </div>
+            </div>
+          </div>
 
-              {/* 목차 미리보기 */}
-              {formData.tableOfContents && formData.tableOfContents.length > 0 && (
-                <div className="space-y-3">
-                  <label className="block text-sm font-semibold text-gray-700">📋 목차 미리보기</label>
-                  <div className="bg-gray-50 border border-gray-200 rounded-xl p-4 max-h-40 overflow-y-auto">
-                    <div className="space-y-2">
-                      {formData.tableOfContents.slice(0, 10).map((item, index) => (
-                        <div key={index} className="flex items-center gap-3 text-sm">
-                          <span className="text-gray-500 min-w-[40px]">{item.number}</span>
-                          <span className="text-gray-700">{item.title}</span>
+          {/* 메인 콘텐츠 영역 */}
+          <div className="p-6">
+            <div className="max-w-4xl mx-auto">
+              <div className="bg-white rounded-xl shadow-sm border border-slate-200 overflow-hidden">
+                {currentStep === 1 && (
+                  <div className="p-8 space-y-8">
+                    <div className="flex items-center gap-3 mb-8">
+                      <div className="w-12 h-12 bg-slate-900 rounded-xl flex items-center justify-center text-white">
+                        <Book className="w-6 h-6" />
+                      </div>
+                      <div>
+                        <h2 className="text-2xl font-bold text-slate-900">기본 정보 입력</h2>
+                        <p className="text-slate-600">PDF 파일을 업로드하면 자동으로 정보를 추출합니다</p>
+                      </div>
+                    </div>
+
+                    {/* 파일 업로드 */}
+                    <div className="space-y-3">
+                      <label className="block text-sm font-semibold text-slate-700">📁 전공 원서 파일 *</label>
+                      <div className="border-2 border-dashed border-slate-300 rounded-xl p-8 text-center hover:border-slate-400 transition-colors">
+                        <div className="flex flex-col items-center space-y-4">
+                          <div className="w-16 h-16 bg-slate-100 rounded-full flex items-center justify-center">
+                            <Upload className="w-8 h-8 text-slate-600" />
+                          </div>
+                          <div>
+                            <FileUpload
+                              onFileChange={handleFileChange}
+                              accept="application/pdf"
+                              label="PDF 파일을 드래그하거나 클릭하여 업로드하세요"
+                              disabled={isAnalyzing}
+                            />
+                            <p className="text-xs text-slate-500 mt-2">최대 100MB까지 업로드 가능</p>
+                          </div>
                         </div>
-                      ))}
-                      {formData.tableOfContents.length > 10 && (
-                        <p className="text-xs text-gray-500 mt-2">
-                          ... 외 {formData.tableOfContents.length - 10}개 항목
-                        </p>
+                      </div>
+                      
+                      {/* 분석 상태 표시 */}
+                      <AnalysisStatus />
+                    </div>
+
+                    {/* 원서 정보 */}
+                    <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+                      <div className="space-y-3">
+                        <label className="block text-sm font-semibold text-slate-700">📖 원서 제목 *</label>
+                        <input
+                          type="text"
+                          value={formData.title}
+                          onChange={(e) => setFormData(prev => ({ ...prev, title: e.target.value }))}
+                          className="w-full border border-slate-300 rounded-lg px-4 py-3 focus:outline-none focus:ring-2 focus:ring-slate-500 focus:border-transparent transition-all duration-300"
+                          placeholder="예: Operating Systems: Three Easy Pieces"
+                          disabled={isAnalyzing}
+                        />
+                        {analysisComplete && formData.title && (
+                          <p className="text-xs text-green-600">✓ PDF에서 자동 추출됨</p>
+                        )}
+                      </div>
+                      
+                      <div className="space-y-3">
+                        <label className="block text-sm font-semibold text-slate-700">✍️ 저자</label>
+                        <input
+                          type="text"
+                          value={formData.author}
+                          onChange={(e) => setFormData(prev => ({ ...prev, author: e.target.value }))}
+                          className="w-full border border-slate-300 rounded-lg px-4 py-3 focus:outline-none focus:ring-2 focus:ring-slate-500 focus:border-transparent transition-all duration-300"
+                          placeholder="예: Remzi H. Arpaci-Dusseau"
+                          disabled={isAnalyzing}
+                        />
+                        {analysisComplete && formData.author && (
+                          <p className="text-xs text-green-600">✓ PDF에서 자동 추출됨</p>
+                        )}
+                      </div>
+                      
+                      <div className="space-y-3">
+                        <label className="block text-sm font-semibold text-slate-700">🏢 출판사</label>
+                        <input
+                          type="text"
+                          value={formData.publisher}
+                          onChange={(e) => setFormData(prev => ({ ...prev, publisher: e.target.value }))}
+                          className="w-full border border-slate-300 rounded-lg px-4 py-3 focus:outline-none focus:ring-2 focus:ring-slate-500 focus:border-transparent transition-all duration-300"
+                          placeholder="예: MIT Press"
+                          disabled={isAnalyzing}
+                        />
+                        {analysisComplete && formData.publisher && (
+                          <p className="text-xs text-green-600">✓ PDF에서 자동 추출됨</p>
+                        )}
+                      </div>
+                      
+                      <div className="space-y-3">
+                        <label className="block text-sm font-semibold text-slate-700">📄 총 페이지 수 *</label>
+                        <input
+                          type="number"
+                          value={formData.totalPages}
+                          onChange={(e) => setFormData(prev => ({ ...prev, totalPages: e.target.value }))}
+                          className="w-full border border-slate-300 rounded-lg px-4 py-3 focus:outline-none focus:ring-2 focus:ring-slate-500 focus:border-transparent transition-all duration-300"
+                          placeholder="예: 400"
+                          disabled={isAnalyzing}
+                        />
+                        {analysisComplete && formData.totalPages && (
+                          <p className="text-xs text-green-600">✓ PDF에서 자동 추출됨</p>
+                        )}
+                      </div>
+                    </div>
+
+                    {/* 과목/주제 (추가 정보) */}
+                    {formData.subject && (
+                      <div className="space-y-3">
+                        <label className="block text-sm font-semibold text-slate-700">📚 과목/주제</label>
+                        <input
+                          type="text"
+                          value={formData.subject}
+                          onChange={(e) => setFormData(prev => ({ ...prev, subject: e.target.value }))}
+                          className="w-full border border-slate-300 rounded-lg px-4 py-3 focus:outline-none focus:ring-2 focus:ring-slate-500 focus:border-transparent transition-all duration-300"
+                          placeholder="예: Computer Science, Operating Systems"
+                          disabled={isAnalyzing}
+                        />
+                        <p className="text-xs text-green-600">✓ PDF에서 자동 추출됨</p>
+                      </div>
+                    )}
+
+                    {/* 목차 미리보기 */}
+                    {formData.tableOfContents && formData.tableOfContents.length > 0 && (
+                      <div className="space-y-3">
+                        <label className="block text-sm font-semibold text-slate-700">📋 목차 미리보기</label>
+                        <div className="bg-slate-50 border border-slate-200 rounded-lg p-4 max-h-40 overflow-y-auto">
+                          <div className="space-y-2">
+                            {formData.tableOfContents.slice(0, 10).map((item, index) => (
+                              <div key={index} className="flex items-center gap-3 text-sm">
+                                <span className="text-slate-500 min-w-[40px]">{item.number}</span>
+                                <span className="text-slate-700">{item.title}</span>
+                              </div>
+                            ))}
+                            {formData.tableOfContents.length > 10 && (
+                              <p className="text-xs text-slate-500 mt-2">
+                                ... 외 {formData.tableOfContents.length - 10}개 항목
+                              </p>
+                            )}
+                          </div>
+                        </div>
+                        <p className="text-xs text-green-600">✓ PDF에서 자동 추출된 목차 ({formData.tableOfContents.length}개 항목)</p>
+                      </div>
+                    )}
+
+                    {/* 학습 기간 */}
+                    <div className="space-y-3">
+                      <label className="block text-sm font-semibold text-slate-700">📅 학습 기간 *</label>
+                      <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+                        <div className="space-y-2">
+                          <label className="block text-xs text-slate-500 font-medium">시작일</label>
+                          <input
+                            type="date"
+                            name="startDate"
+                            value={formData.startDate}
+                            onChange={handleDateChange}
+                            className="w-full border border-slate-300 rounded-lg px-4 py-3 focus:outline-none focus:ring-2 focus:ring-slate-500 focus:border-transparent transition-all duration-300"
+                            disabled={isAnalyzing}
+                          />
+                        </div>
+                        <div className="space-y-2">
+                          <label className="block text-xs text-slate-500 font-medium">목표 완료일</label>
+                          <input
+                            type="date"
+                            name="endDate"
+                            value={formData.endDate}
+                            onChange={handleDateChange}
+                            className="w-full border border-slate-300 rounded-lg px-4 py-3 focus:outline-none focus:ring-2 focus:ring-slate-500 focus:border-transparent transition-all duration-300"
+                            disabled={isAnalyzing}
+                          />
+                        </div>
+                      </div>
+                      {daysLeft !== null && daysLeft > 0 && (
+                        <div className="bg-blue-50 border border-blue-200 rounded-lg p-4">
+                          <div className="flex items-center gap-2">
+                            <span className="text-blue-600">📊</span>
+                            <span className="text-sm font-medium text-blue-700">
+                              총 {daysLeft}일의 학습 기간이 설정되었습니다
+                              {formData.totalPages && (
+                                <span className="ml-2">
+                                  (하루 평균 {Math.ceil(parseInt(formData.totalPages) / daysLeft)}페이지)
+                                </span>
+                              )}
+                            </span>
+                          </div>
+                        </div>
                       )}
                     </div>
-                  </div>
-                  <p className="text-xs text-green-600">✓ PDF에서 자동 추출된 목차 ({formData.tableOfContents.length}개 항목)</p>
-                </div>
-              )}
 
-              {/* 학습 기간 */}
-              <div className="space-y-3">
-                <label className="block text-sm font-semibold text-gray-700">📅 학습 기간 *</label>
-                <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-                  <div className="space-y-2">
-                    <label className="block text-xs text-gray-500 font-medium">시작일</label>
-                    <input
-                      type="date"
-                      name="startDate"
-                      value={formData.startDate}
-                      onChange={handleDateChange}
-                      className="w-full border border-gray-300 rounded-xl px-4 py-3 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all duration-300"
-                      disabled={isAnalyzing}
-                    />
-                  </div>
-                  <div className="space-y-2">
-                    <label className="block text-xs text-gray-500 font-medium">목표 완료일</label>
-                    <input
-                      type="date"
-                      name="endDate"
-                      value={formData.endDate}
-                      onChange={handleDateChange}
-                      className="w-full border border-gray-300 rounded-xl px-4 py-3 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all duration-300"
-                      disabled={isAnalyzing}
-                    />
-                  </div>
-                </div>
-                {daysLeft !== null && daysLeft > 0 && (
-                  <div className="bg-blue-50 border border-blue-200 rounded-xl p-4">
-                    <div className="flex items-center gap-2">
-                      <span className="text-blue-600">📊</span>
-                      <span className="text-sm font-medium text-blue-700">
-                        총 {daysLeft}일의 학습 기간이 설정되었습니다
-                        {formData.totalPages && (
-                          <span className="ml-2">
-                            (하루 평균 {Math.ceil(parseInt(formData.totalPages) / daysLeft)}페이지)
-                          </span>
+                    <div className="flex justify-end pt-6 border-t border-slate-200">
+                      <Button
+                        onClick={() => setCurrentStep(2)}
+                        disabled={!formData.title || !formData.totalPages || !formData.startDate || !formData.endDate || isAnalyzing}
+                        className="px-8 py-3 bg-slate-900 text-white hover:bg-slate-800 transition-all duration-300 disabled:opacity-50 disabled:cursor-not-allowed"
+                      >
+                        {isAnalyzing ? (
+                          <>
+                            <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+                            분석 중...
+                          </>
+                        ) : (
+                          '다음 단계 →'
                         )}
-                      </span>
+                      </Button>
+                    </div>
+                  </div>
+                )}
+
+                {currentStep === 2 && (
+                  <div className="p-8 space-y-8">
+                    <div className="flex items-center gap-3 mb-8">
+                      <div className="w-12 h-12 bg-slate-900 rounded-xl flex items-center justify-center text-white">
+                        <Target className="w-6 h-6" />
+                      </div>
+                      <div>
+                        <h2 className="text-2xl font-bold text-slate-900">학습 계획 설정</h2>
+                        <p className="text-slate-600">목표에 맞는 학습 계획을 세워보세요</p>
+                      </div>
+                    </div>
+
+                    {/* 학습 목적 */}
+                    <div className="space-y-3">
+                      <label className="block text-sm font-semibold text-slate-700">🎯 학습 목적 *</label>
+                      <input
+                        type="text"
+                        value={formData.purpose}
+                        onChange={(e) => setFormData(prev => ({ ...prev, purpose: e.target.value }))}
+                        className="w-full border border-slate-300 rounded-lg px-4 py-3 focus:outline-none focus:ring-2 focus:ring-slate-500 focus:border-transparent transition-all duration-300"
+                        placeholder="예: 전공 심화 학습, 자격증 대비, 연구 목적, 취업 준비 등"
+                      />
+                    </div>
+
+                    {/* 학습 강도 */}
+                    <div className="space-y-3">
+                      <label className="block text-sm font-semibold text-slate-700">⚡ 학습 강도</label>
+                      <div className="grid grid-cols-3 gap-4">
+                        {intensityOptions.map(option => (
+                          <button
+                            key={option}
+                            onClick={() => setFormData(prev => ({ ...prev, intensity: option }))}
+                            className={`p-4 rounded-lg border-2 transition-all duration-300 ${
+                              formData.intensity === option
+                                ? 'border-slate-900 bg-slate-50 text-slate-900'
+                                : 'border-slate-200 bg-white text-slate-700 hover:border-slate-300'
+                            }`}
+                          >
+                            <div className="text-center">
+                              <div className="text-lg font-semibold">{option}</div>
+                              <div className="text-xs mt-1">
+                                {option === '낮음' && '천천히 꼼꼼히'}
+                                {option === '보통' && '적당한 속도로'}
+                                {option === '높음' && '빠르게 집중적으로'}
+                              </div>
+                            </div>
+                          </button>
+                        ))}
+                      </div>
+                    </div>
+
+                    {/* 학습 계획 미리보기 */}
+                    {daysLeft && formData.totalPages && (
+                      <div className="bg-slate-50 border border-slate-200 rounded-lg p-6">
+                        <h3 className="text-lg font-semibold text-slate-900 mb-4">📈 예상 학습 계획</h3>
+                        <div className="grid grid-cols-1 md:grid-cols-3 gap-4 text-sm">
+                          <div className="bg-white p-4 rounded-lg">
+                            <div className="text-slate-500 mb-1">총 학습 기간</div>
+                            <div className="text-xl font-bold text-slate-900">{daysLeft}일</div>
+                          </div>
+                          <div className="bg-white p-4 rounded-lg">
+                            <div className="text-slate-500 mb-1">하루 평균</div>
+                            <div className="text-xl font-bold text-slate-900">
+                              {Math.ceil(parseInt(formData.totalPages) / daysLeft)}페이지
+                            </div>
+                          </div>
+                          <div className="bg-white p-4 rounded-lg">
+                            <div className="text-slate-500 mb-1">예상 주차</div>
+                            <div className="text-xl font-bold text-slate-900">
+                              {Math.ceil(daysLeft / 7)}주
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    )}
+
+                    {/* AI 플랜 생성 */}
+                    <div className="space-y-4">
+                      <label className="block text-sm font-semibold text-slate-700">🤖 스마트 학습 플랜 생성 *</label>
+                      <div className="flex gap-3">
+                        <button
+                          onClick={handleGeneratePlan}
+                          disabled={!formData.totalPages || !daysLeft}
+                          className="flex-1 bg-slate-900 text-white rounded-lg px-6 py-4 font-semibold hover:bg-slate-800 transition-all duration-300 flex items-center justify-center gap-3 disabled:opacity-50 disabled:cursor-not-allowed"
+                        >
+                          <Brain className="w-5 h-5" />
+                          {formData.tableOfContents.length > 0 ? '목차 기반 플랜 생성' : '페이지 기반 플랜 생성'}
+                        </button>
+                        {planTasks.length > 0 && (
+                          <button
+                            onClick={() => setPlanTasks([])}
+                            className="px-6 py-4 bg-slate-200 text-slate-700 rounded-lg font-semibold hover:bg-slate-300 transition-all duration-300"
+                          >
+                            초기화
+                          </button>
+                        )}
+                      </div>
+                      
+                      {/* 생성된 플랜 미리보기 */}
+                      {planTasks.length > 0 && (
+                        <div className="bg-white border border-slate-200 rounded-lg p-6">
+                          <h4 className="text-lg font-semibold text-slate-900 mb-4">
+                            📋 생성된 학습 계획 ({planTasks.length}주차)
+                          </h4>
+                          <div className="space-y-3 max-h-60 overflow-y-auto">
+                            {planTasks.map((task, index) => (
+                              <div key={index} className="flex items-center gap-4 p-3 bg-slate-50 rounded-lg">
+                                <div className="w-8 h-8 bg-slate-100 text-slate-600 rounded-full flex items-center justify-center text-sm font-bold">
+                                  {task.week}
+                                </div>
+                                <div className="flex-1">
+                                  <div className="font-medium text-slate-900">{task.title || task.task}</div>
+                                  {task.memo && (
+                                    <div className="text-sm text-slate-600">{task.memo}</div>
+                                  )}
+                                  {task.pages && (
+                                    <div className="text-xs text-slate-600 mt-1">약 {task.pages}페이지</div>
+                                  )}
+                                </div>
+                              </div>
+                            ))}
+                          </div>
+                        </div>
+                      )}
+                      
+                      <AIPlanGenerator
+                        studyIntensity={formData.intensity}
+                        onGenerate={handleGeneratePlan}
+                        planTasks={planTasks}
+                        setPlanTasks={setPlanTasks}
+                      />
+                    </div>
+
+                    <div className="flex justify-between pt-6 border-t border-slate-200">
+                      <Button
+                        onClick={() => setCurrentStep(1)}
+                        variant="secondary"
+                        className="px-8 py-3 bg-slate-200 text-slate-700 hover:bg-slate-300"
+                      >
+                        ← 이전 단계
+                      </Button>
+                      <Button
+                        onClick={handleSave}
+                        disabled={!formData.purpose || planTasks.length === 0}
+                        className="px-8 py-3 bg-slate-900 text-white hover:bg-slate-800 transition-all duration-300 disabled:opacity-50 disabled:cursor-not-allowed"
+                      >
+                        <Plus className="w-4 h-4 mr-2" />
+                        원서 추가 완료
+                      </Button>
                     </div>
                   </div>
                 )}
               </div>
-
-              <div className="flex justify-end pt-6">
-                <Button
-                  onClick={() => setCurrentStep(2)}
-                  disabled={!formData.title || !formData.totalPages || !formData.startDate || !formData.endDate || isAnalyzing}
-                  className="px-8 py-3 bg-gradient-to-r from-blue-600 to-indigo-600 hover:from-blue-700 hover:to-indigo-700 shadow-lg hover:shadow-xl transition-all duration-300 disabled:opacity-50 disabled:cursor-not-allowed"
-                >
-                  {isAnalyzing ? (
-                    <>
-                      <Loader2 className="w-4 h-4 mr-2 animate-spin" />
-                      분석 중...
-                    </>
-                  ) : (
-                    '다음 단계 →'
-                  )}
-                </Button>
-              </div>
             </div>
-          )}
-
-          {currentStep === 2 && (
-            <div className="p-8 space-y-8">
-              <div className="flex items-center gap-3 mb-8">
-                <div className="w-12 h-12 bg-gradient-to-r from-green-500 to-teal-600 rounded-xl flex items-center justify-center text-white">
-                  <Target className="w-6 h-6" />
-                </div>
-                <div>
-                  <h2 className="text-2xl font-bold text-gray-900">학습 계획 설정</h2>
-                  <p className="text-gray-600">목표에 맞는 학습 계획을 세워보세요</p>
-                </div>
-              </div>
-
-              {/* 학습 목적 */}
-              <div className="space-y-3">
-                <label className="block text-sm font-semibold text-gray-700">🎯 학습 목적 *</label>
-                <input
-                  type="text"
-                  value={formData.purpose}
-                  onChange={(e) => setFormData(prev => ({ ...prev, purpose: e.target.value }))}
-                  className="w-full border border-gray-300 rounded-xl px-4 py-3 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all duration-300"
-                  placeholder="예: 전공 심화 학습, 자격증 대비, 연구 목적, 취업 준비 등"
-                />
-              </div>
-
-              {/* 학습 강도 */}
-              <div className="space-y-3">
-                <label className="block text-sm font-semibold text-gray-700">⚡ 학습 강도</label>
-                <div className="grid grid-cols-3 gap-4">
-                  {intensityOptions.map(option => (
-                    <button
-                      key={option}
-                      onClick={() => setFormData(prev => ({ ...prev, intensity: option }))}
-                      className={`p-4 rounded-xl border-2 transition-all duration-300 ${
-                        formData.intensity === option
-                          ? 'border-blue-500 bg-blue-50 text-blue-700'
-                          : 'border-gray-200 bg-white text-gray-700 hover:border-gray-300'
-                      }`}
-                    >
-                      <div className="text-center">
-                        <div className="text-lg font-semibold">{option}</div>
-                        <div className="text-xs mt-1">
-                          {option === '낮음' && '천천히 꼼꼼히'}
-                          {option === '보통' && '적당한 속도로'}
-                          {option === '높음' && '빠르게 집중적으로'}
-                        </div>
-                      </div>
-                    </button>
-                  ))}
-                </div>
-              </div>
-
-              {/* 학습 계획 미리보기 */}
-              {daysLeft && formData.totalPages && (
-                <div className="bg-gray-50 border border-gray-200 rounded-xl p-6">
-                  <h3 className="text-lg font-semibold text-gray-900 mb-4">📈 예상 학습 계획</h3>
-                  <div className="grid grid-cols-1 md:grid-cols-3 gap-4 text-sm">
-                    <div className="bg-white p-4 rounded-lg">
-                      <div className="text-gray-500 mb-1">총 학습 기간</div>
-                      <div className="text-xl font-bold text-blue-600">{daysLeft}일</div>
-                    </div>
-                    <div className="bg-white p-4 rounded-lg">
-                      <div className="text-gray-500 mb-1">하루 평균</div>
-                      <div className="text-xl font-bold text-green-600">
-                        {Math.ceil(parseInt(formData.totalPages) / daysLeft)}페이지
-                      </div>
-                    </div>
-                    <div className="bg-white p-4 rounded-lg">
-                      <div className="text-gray-500 mb-1">예상 주차</div>
-                      <div className="text-xl font-bold text-purple-600">
-                        {Math.ceil(daysLeft / 7)}주
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              )}
-
-              {/* AI 플랜 생성 */}
-              <div className="space-y-4">
-                <label className="block text-sm font-semibold text-gray-700">🤖 스마트 학습 플랜 생성 *</label>
-                <div className="flex gap-3">
-                  <button
-                    onClick={handleGeneratePlan}
-                    disabled={!formData.totalPages || !daysLeft}
-                    className="flex-1 bg-gradient-to-r from-purple-600 to-blue-600 text-white rounded-xl px-6 py-4 font-semibold hover:from-purple-700 hover:to-blue-700 transition-all duration-300 flex items-center justify-center gap-3 disabled:opacity-50 disabled:cursor-not-allowed"
-                  >
-                    <Brain className="w-5 h-5" />
-                    {formData.tableOfContents.length > 0 ? '목차 기반 플랜 생성' : '페이지 기반 플랜 생성'}
-                  </button>
-                  {planTasks.length > 0 && (
-                    <button
-                      onClick={() => setPlanTasks([])}
-                      className="px-6 py-4 bg-gray-200 text-gray-700 rounded-xl font-semibold hover:bg-gray-300 transition-all duration-300"
-                    >
-                      초기화
-                    </button>
-                  )}
-                </div>
-                
-                {/* 생성된 플랜 미리보기 */}
-                {planTasks.length > 0 && (
-                  <div className="bg-white border border-gray-200 rounded-xl p-6">
-                    <h4 className="text-lg font-semibold text-gray-900 mb-4">
-                      📋 생성된 학습 계획 ({planTasks.length}주차)
-                    </h4>
-                    <div className="space-y-3 max-h-60 overflow-y-auto">
-                      {planTasks.map((task, index) => (
-                        <div key={index} className="flex items-center gap-4 p-3 bg-gray-50 rounded-lg">
-                          <div className="w-8 h-8 bg-blue-100 text-blue-600 rounded-full flex items-center justify-center text-sm font-bold">
-                            {task.week}
-                          </div>
-                          <div className="flex-1">
-                            <div className="font-medium text-gray-900">{task.title || task.task}</div>
-                            {task.memo && (
-                              <div className="text-sm text-gray-600">{task.memo}</div>
-                            )}
-                            {task.pages && (
-                              <div className="text-xs text-blue-600 mt-1">약 {task.pages}페이지</div>
-                            )}
-                          </div>
-                        </div>
-                      ))}
-                    </div>
-                  </div>
-                )}
-                
-                <AIPlanGenerator
-                  studyIntensity={formData.intensity}
-                  onGenerate={handleGeneratePlan}
-                  planTasks={planTasks}
-                  setPlanTasks={setPlanTasks}
-                />
-              </div>
-
-              <div className="flex justify-between pt-6">
-                <Button
-                  onClick={() => setCurrentStep(1)}
-                  variant="secondary"
-                  className="px-8 py-3"
-                >
-                  ← 이전 단계
-                </Button>
-                <Button
-                  onClick={handleSave}
-                  disabled={!formData.purpose || planTasks.length === 0}
-                  className="px-8 py-3 bg-gradient-to-r from-green-600 to-teal-600 hover:from-green-700 hover:to-teal-700 shadow-lg hover:shadow-xl transition-all duration-300 disabled:opacity-50 disabled:cursor-not-allowed"
-                >
-                  <FileText className="w-4 h-4 mr-2" />
-                  원서 추가 완료
-                </Button>
-              </div>
-            </div>
-          )}
+          </div>
         </div>
       </div>
 

--- a/src/pages/TextbookManagement/index.js
+++ b/src/pages/TextbookManagement/index.js
@@ -1,44 +1,36 @@
 import { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import Button from '../../components/common/Button';
-import { Plus, Book, Library } from 'lucide-react';
+import { Plus, Search, MoreHorizontal, BookOpen, Calendar, Target, TrendingUp, Sparkles, Trash2 } from 'lucide-react';
 import { useStudyContext } from '../../context/StudyContext';
 
 export default function TextbookManagement() {
   const navigate = useNavigate();
   const { textbooks, deleteTextbook } = useStudyContext();
   const [books, setBooks] = useState([]);
+  const [searchQuery, setSearchQuery] = useState('');
+  const [filterStatus, setFilterStatus] = useState('전체');
+  const [viewMode, setViewMode] = useState('grid'); // 'grid' | 'list'
 
   // 제목을 간단하게 표시하는 함수
   const getShortTitle = (title) => {
     if (!title) return '';
-    
-    // 파일명에서 추출된 긴 제목을 간단하게 처리
-    // 첫 번째 하이픈이나 대시 이전의 부분만 사용
     const shortTitle = title.split(/[-–—]/)[0].trim();
-    
-    // 25자 이상이면 "..." 추가
-    if (shortTitle.length > 25) {
-      return shortTitle.substring(0, 25) + '...';
+    if (shortTitle.length > 30) {
+      return shortTitle.substring(0, 30) + '...';
     }
-    
     return shortTitle;
   };
 
-  // 컴포넌트 마운트 시 StudyContext의 textbooks 데이터 사용
   useEffect(() => {
     setBooks(textbooks);
   }, [textbooks]);
 
-  const [filterStatus, setFilterStatus] = useState('전체');
-
   const openBookDetail = (book) => {
-    // 상세 페이지로 이동
     navigate(`/textbook/${book.id}`);
   };
 
   const openAddBookPage = () => {
-    // 새 원서 생성 페이지로 이동
     navigate('/textbook/add');
   };
 
@@ -66,52 +58,45 @@ export default function TextbookManagement() {
     return `${date.getMonth() + 1}/${date.getDate()}`;
   };
 
+  // 검색 및 필터링
   const filteredBooks = books.filter(book => {
-    if (filterStatus === '전체') return true;
-    return book.status === filterStatus;
+    const matchesSearch = book.title.toLowerCase().includes(searchQuery.toLowerCase()) ||
+                         book.author.toLowerCase().includes(searchQuery.toLowerCase());
+    const matchesFilter = filterStatus === '전체' || book.status === filterStatus;
+    return matchesSearch && matchesFilter;
   });
+
+  // 통계 데이터
+  const stats = {
+    total: books.length,
+    reading: books.filter(b => b.status === '읽는 중').length,
+    completed: books.filter(b => b.status === '완료').length,
+    notStarted: books.filter(b => b.status === '미시작').length
+  };
 
   const BookCard = ({ book }) => {
     const progressPercentage = getProgressPercentage(book.currentPage, book.totalPages);
     const recommendedPages = getRecommendedDailyPages(book);
-    const statusColor = {
-      '읽는 중': 'bg-blue-100 text-blue-800 border-blue-200',
-      '완료': 'bg-green-100 text-green-800 border-green-200',
-      '미시작': 'bg-gray-100 text-gray-800 border-gray-200'
+    const daysRemaining = getDaysRemaining(book.targetDate);
+    
+    const statusStyles = {
+      '읽는 중': { bg: 'bg-blue-50', text: 'text-blue-700', border: 'border-blue-200', dot: 'bg-blue-500' },
+      '완료': { bg: 'bg-emerald-50', text: 'text-emerald-700', border: 'border-emerald-200', dot: 'bg-emerald-500' },
+      '미시작': { bg: 'bg-slate-50', text: 'text-slate-700', border: 'border-slate-200', dot: 'bg-slate-400' }
     }[book.status];
 
-    const statusIcon = {
-      '읽는 중': '📖',
-      '완료': '✅',
-      '미시작': '📚'
-    }[book.status];
-
-    // 원서 삭제 핸들러
     const handleDelete = (e) => {
       e.stopPropagation();
-      if (window.confirm('정말 이 원서를 삭제하시겠습니까?\n\n삭제된 원서는 복구할 수 없습니다.')) {
+      if (window.confirm('정말 이 원서를 삭제하시겠습니까?')) {
         try {
-          // StudyContext의 deleteTextbook 함수 사용
           deleteTextbook(book.id);
           
-          // 청크 데이터 삭제 (있는 경우)
           if (book.file && book.file.isChunked && book.file.totalChunks) {
-            console.log('청크 데이터 삭제 시작:', {
-              bookId: book.id,
-              totalChunks: book.file.totalChunks
-            });
-            
             for (let i = 0; i < book.file.totalChunks; i++) {
               const chunkKey = `textbook_${book.id}_chunk_${i}`;
               localStorage.removeItem(chunkKey);
-              console.log('청크 삭제:', chunkKey);
             }
-            
-            console.log('청크 데이터 삭제 완료');
           }
-          
-          // 성공 메시지
-          alert('원서가 성공적으로 삭제되었습니다.');
           
         } catch (error) {
           console.error('원서 삭제 중 오류:', error);
@@ -122,143 +107,122 @@ export default function TextbookManagement() {
 
     return (
       <div 
-        className="group bg-white rounded-2xl shadow-sm hover:shadow-xl transition-all duration-300 cursor-pointer border border-gray-100 overflow-hidden hover:border-blue-200"
+        className="group bg-white border border-slate-200 rounded-xl hover:border-slate-300 hover:shadow-lg transition-all duration-200 cursor-pointer overflow-hidden"
         onClick={() => openBookDetail(book)}
       >
-        {/* 상단 이미지 영역 */}
-        <div className="relative h-48 bg-gradient-to-br from-blue-50 to-indigo-100 flex items-center justify-center">
-          <div className="absolute inset-0 bg-gradient-to-t from-black/10 to-transparent"></div>
-          <div className="relative z-10 text-center">
-            <div className="text-4xl mb-2">📚</div>
-            <div className="text-xs text-gray-600 bg-white/80 backdrop-blur-sm rounded-full px-3 py-1">
-              {book.publisher}
+        {/* 카드 헤더 */}
+        <div className="p-5 pb-4 border-b border-slate-100">
+          <div className="flex items-start justify-between">
+            <div className="flex-1 min-w-0">
+              <div className="flex items-center gap-2 mb-2">
+                <div className={`w-2 h-2 rounded-full ${statusStyles.dot}`}></div>
+                <span className={`text-xs font-medium px-2 py-1 rounded-md ${statusStyles.bg} ${statusStyles.text}`}>
+                  {book.status}
+                </span>
+              </div>
+              <h3 className="font-semibold text-slate-900 text-lg leading-tight mb-1 group-hover:text-blue-600 transition-colors" title={book.title}>
+                {getShortTitle(book.title)}
+              </h3>
+              <p className="text-sm text-slate-500">{book.author}</p>
+            </div>
+            <div className="flex items-center gap-1 ml-3">
+              <button
+                className="opacity-0 group-hover:opacity-100 p-1.5 text-slate-400 hover:text-red-500 hover:bg-red-50 rounded-md transition-all"
+                onClick={handleDelete}
+                title="삭제"
+              >
+                <Trash2 size={16} />
+              </button>
+              <button className="opacity-0 group-hover:opacity-100 p-1.5 text-slate-400 hover:text-slate-600 hover:bg-slate-100 rounded-md transition-all">
+                <MoreHorizontal size={16} />
+              </button>
             </div>
           </div>
-          {/* 상태 배지 */}
-          <div className={`absolute top-3 right-3 px-3 py-1 rounded-full text-xs font-medium border ${statusColor}`}>
-            <span className="mr-1">{statusIcon}</span>
-            {book.status}
-          </div>
-          {/* 삭제 버튼 */}
-          <button
-            className="absolute top-3 left-3 bg-red-100 text-red-600 rounded-full px-2 py-1 text-xs font-semibold shadow hover:bg-red-200 transition"
-            onClick={handleDelete}
-            title="원서 삭제"
-          >
-            삭제
-          </button>
         </div>
 
-        {/* 콘텐츠 영역 */}
-        <div className="p-6">
-          {/* 제목과 저자 */}
-          <div className="mb-4">
-            <h3 className="text-lg font-bold text-gray-900 line-clamp-2 mb-2 group-hover:text-blue-600 transition-colors" title={book.title}>
-              {getShortTitle(book.title)}
-            </h3>
-            <p className="text-sm text-gray-600 flex items-center">
-              <span className="mr-2">✍️</span>
-              {book.author}
-            </p>
+        {/* 진행률 */}
+        <div className="p-5 pt-4">
+          <div className="flex items-center justify-between mb-2">
+            <span className="text-sm font-medium text-slate-700">진행률</span>
+            <span className="text-sm text-slate-500">{progressPercentage}%</span>
+          </div>
+          <div className="w-full bg-slate-100 rounded-full h-2 mb-3">
+            <div 
+              className="h-full bg-gradient-to-r from-blue-500 to-blue-600 rounded-full transition-all duration-300"
+              style={{ width: `${progressPercentage}%` }}
+            />
+          </div>
+          
+          {/* 통계 정보 */}
+          <div className="grid grid-cols-3 gap-3 mb-4">
+            <div className="text-center">
+              <div className="text-xs text-slate-500 mb-1">목표일</div>
+              <div className="text-sm font-medium text-slate-700">{formatDate(book.targetDate)}</div>
+            </div>
+            <div className="text-center">
+              <div className="text-xs text-slate-500 mb-1">남은 일수</div>
+              <div className={`text-sm font-medium ${daysRemaining < 7 ? 'text-red-600' : 'text-slate-700'}`}>
+                {daysRemaining}일
+              </div>
+            </div>
+            <div className="text-center">
+              <div className="text-xs text-slate-500 mb-1">일일 권장</div>
+              <div className="text-sm font-medium text-blue-600">{recommendedPages}p</div>
+            </div>
           </div>
 
-          {/* 진행률 */}
-          <div className="mb-4">
-            <div className="flex justify-between items-center mb-2">
-              <span className="text-sm font-medium text-gray-700">진행률</span>
-              <span className="text-sm text-gray-500">{progressPercentage}%</span>
-            </div>
-            <div className="w-full bg-gray-200 rounded-full h-2 overflow-hidden">
-              <div 
-                className="h-full bg-gradient-to-r from-blue-500 to-blue-600 rounded-full transition-all duration-500"
-                style={{ width: `${progressPercentage}%` }}
-              ></div>
-            </div>
-            <div className="flex justify-between text-xs text-gray-500 mt-1">
-              <span>{book.currentPage}p</span>
-              <span>{book.totalPages}p</span>
-            </div>
-          </div>
-
-          {/* 학습 정보 */}
-          <div className="space-y-2 mb-4">
-            <div className="flex items-center justify-between text-xs">
-              <span className="text-gray-500">목표일</span>
-              <span className="font-medium text-gray-700">{formatDate(book.targetDate)}</span>
-            </div>
-            <div className="flex items-center justify-between text-xs">
-              <span className="text-gray-500">남은 일수</span>
-              <span className={`font-medium ${getDaysRemaining(book.targetDate) < 7 ? 'text-red-600' : 'text-gray-700'}`}>
-                {getDaysRemaining(book.targetDate)}일
-              </span>
-            </div>
-            <div className="flex items-center justify-between text-xs">
-              <span className="text-gray-500">일일 권장</span>
-              <span className="font-medium text-blue-600">{recommendedPages}p</span>
-            </div>
+          {/* 페이지 정보 */}
+          <div className="flex items-center justify-between text-xs text-slate-500 mb-4">
+            <span>{book.currentPage}p 읽음</span>
+            <span>총 {book.totalPages}p</span>
           </div>
 
           {/* 액션 버튼 */}
           <div className="flex gap-2">
-            <button 
-              className="flex-1 bg-blue-50 text-blue-700 py-2 px-3 rounded-lg text-sm font-medium hover:bg-blue-100 transition-colors"
+            <Button 
+              className="flex-1 bg-slate-900 text-white py-2.5 px-3 rounded-lg text-sm font-medium hover:bg-slate-800 transition-colors"
               onClick={(e) => {
                 e.stopPropagation();
                 openBookDetail(book);
               }}
             >
-              📖 읽기
-            </button>
+              읽기 계속
+            </Button>
             <button 
-              className="flex-1 bg-gray-50 text-gray-700 py-2 px-3 rounded-lg text-sm font-medium hover:bg-gray-100 transition-colors"
+              className="px-3 py-2.5 border border-slate-200 text-slate-600 rounded-lg text-sm font-medium hover:bg-slate-50 transition-colors"
               onClick={(e) => {
                 e.stopPropagation();
-                // 노트 보기 기능
               }}
             >
-              📝 노트
+              노트
             </button>
-        </div>
+          </div>
         </div>
       </div>
     );
   };
 
-  // 전체 원서 삭제 핸들러
   const handleDeleteAll = () => {
-    try {
-      console.log('즉시 정리 시작');
-      
-      // localStorage 완전 초기화
-      localStorage.clear();
-      console.log('localStorage 완전 초기화 완료');
-      
-      // 상태 업데이트
-      setBooks([]);
-      
-      console.log('즉시 정리 완료');
-      alert('모든 데이터가 즉시 정리되었습니다.\nlocalStorage가 완전히 초기화되었습니다.');
-      
-    } catch (error) {
-      console.error('즉시 정리 중 오류:', error);
-      alert('즉시 정리 중 오류가 발생했습니다.');
+    if (window.confirm('모든 원서 데이터를 삭제하시겠습니까?\n\n이 작업은 되돌릴 수 없습니다.')) {
+      try {
+        localStorage.clear();
+        setBooks([]);
+        alert('모든 데이터가 삭제되었습니다.');
+      } catch (error) {
+        console.error('데이터 삭제 중 오류:', error);
+        alert('데이터 삭제 중 오류가 발생했습니다.');
+      }
     }
   };
 
-  // localStorage 정리 (고아 청크 데이터 삭제)
   const cleanupOrphanedChunks = () => {
     try {
-      console.log('고아 청크 데이터 정리 시작');
-      
-      // 현재 원서 ID 목록
       const savedBooks = JSON.parse(localStorage.getItem('textbooks') || '[]');
       const bookIds = savedBooks.map(book => book.id);
       
-      // 모든 localStorage 키 확인
       const allKeys = Object.keys(localStorage);
       const chunkKeys = allKeys.filter(key => key.startsWith('textbook_') && key.includes('chunk_'));
       
-      // 고아 청크 찾기 및 삭제
       let deletedCount = 0;
       chunkKeys.forEach(key => {
         const match = key.match(/textbook_(\d+)_chunk_(\d+)/);
@@ -267,125 +231,184 @@ export default function TextbookManagement() {
           if (!bookIds.includes(bookId)) {
             localStorage.removeItem(key);
             deletedCount++;
-            console.log('고아 청크 삭제:', key);
           }
         }
       });
       
-      console.log(`고아 청크 ${deletedCount}개 삭제 완료`);
       return deletedCount;
-      
     } catch (error) {
-      console.error('고아 청크 정리 중 오류:', error);
+      console.error('정리 중 오류:', error);
       return 0;
     }
   };
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-slate-50 via-blue-50 to-indigo-50">
-      {/* 해더 */}
-      <div className="bg-white/95 backdrop-blur-xl border-b border-slate-200/60 sticky top-0 z-20 shadow-sm">
-        <div className="max-w mx-auto px-6 py-3 flex items-center justify-between">
-          <div className="flex items-center gap-3">
-            <div className="p-2 bg-gradient-to-br from-blue-500 to-purple-600 rounded-xl shadow-lg">
-              <Book size={24} className="text-white" />
-            </div>
-            <div>
-              <h1 className="text-xl font-bold bg-gradient-to-r from-slate-900 to-slate-600 bg-clip-text text-transparent">
-                원서 관리
-              </h1>
-              <p className="text-xs text-slate-600 mt-0.5">진행 중인 원서들을 한눈에 관리하세요!</p>
+    <div className="min-h-screen bg-slate-50">
+      {/* 사이드바 공간 (필요시 추가) */}
+      <div className="flex">
+        {/* 메인 콘텐츠 */}
+        <div className="flex-1">
+          {/* 상단 바 */}
+          <div className="bg-white border-b border-slate-200 sticky top-0 z-10">
+            <div className="px-6 py-4">
+              <div className="flex items-center justify-between">
+                {/* 페이지 제목 */}
+                <div>
+                  <h1 className="text-2xl font-bold text-slate-900">원서 관리</h1>
+                  <p className="text-sm text-slate-600 mt-0.5">학습 중인 원서를 관리하고 진행상황을 확인하세요</p>
+                </div>
+
+                {/* 우측 액션 버튼들 */}
+                <div className="flex items-center gap-3">
+                  <button 
+                    className="px-3 py-2 text-sm text-slate-600 hover:text-slate-800 hover:bg-slate-100 rounded-md transition-colors"
+                    onClick={() => {
+                      const count = cleanupOrphanedChunks();
+                      alert(count > 0 ? `${count}개 항목을 정리했습니다.` : '정리할 항목이 없습니다.');
+                    }}
+                  >
+                    <Sparkles size={16} className="mr-1.5" />
+                    정리
+                  </button>
+                  <button 
+                    className="px-3 py-2 text-sm text-red-600 hover:text-red-700 hover:bg-red-50 rounded-md transition-colors"
+                    onClick={handleDeleteAll}
+                  >
+                    <Trash2 size={16} className="mr-1.5" />
+                    전체 삭제
+                  </button>
+                  <Button 
+                    onClick={openAddBookPage}
+                    className="bg-slate-900 text-white px-4 py-2 rounded-md text-sm font-medium hover:bg-slate-800 transition-colors flex items-center gap-2"
+                  >
+                    <Plus size={16} />
+                    새 원서
+                  </Button>
+                </div>
+              </div>
+
+              {/* 통계 카드들 */}
+              <div className="grid grid-cols-4 gap-4 mt-6">
+                <div className="bg-slate-50 rounded-lg p-4">
+                  <div className="flex items-center gap-3">
+                    <div className="p-2 bg-slate-100 rounded-lg">
+                      <BookOpen size={20} className="text-slate-600" />
+                    </div>
+                    <div>
+                      <div className="text-2xl font-bold text-slate-900">{stats.total}</div>
+                      <div className="text-sm text-slate-500">전체 원서</div>
+                    </div>
+                  </div>
+                </div>
+                <div className="bg-blue-50 rounded-lg p-4">
+                  <div className="flex items-center gap-3">
+                    <div className="p-2 bg-blue-100 rounded-lg">
+                      <TrendingUp size={20} className="text-blue-600" />
+                    </div>
+                    <div>
+                      <div className="text-2xl font-bold text-blue-900">{stats.reading}</div>
+                      <div className="text-sm text-blue-600">읽는 중</div>
+                    </div>
+                  </div>
+                </div>
+                <div className="bg-emerald-50 rounded-lg p-4">
+                  <div className="flex items-center gap-3">
+                    <div className="p-2 bg-emerald-100 rounded-lg">
+                      <Target size={20} className="text-emerald-600" />
+                    </div>
+                    <div>
+                      <div className="text-2xl font-bold text-emerald-900">{stats.completed}</div>
+                      <div className="text-sm text-emerald-600">완료</div>
+                    </div>
+                  </div>
+                </div>
+                <div className="bg-orange-50 rounded-lg p-4">
+                  <div className="flex items-center gap-3">
+                    <div className="p-2 bg-orange-100 rounded-lg">
+                      <Calendar size={20} className="text-orange-600" />
+                    </div>
+                    <div>
+                      <div className="text-2xl font-bold text-orange-900">{stats.notStarted}</div>
+                      <div className="text-sm text-orange-600">예정</div>
+                    </div>
+                  </div>
+                </div>
+              </div>
             </div>
           </div>
-          
-          <div className="flex items-center gap-3">
-            <div className="flex items-center gap-2 bg-slate-50/80 backdrop-blur px-3 py-2 rounded-lg border border-slate-200/50">
-              <Library size={16} className="text-blue-500" />
-              <span className="text-xs text-slate-600">총 {books.length}권</span>
-            </div>
-            
-            {/* 정리 버튼 */}
-            <button 
-              className="px-3 py-2.5 bg-gray-100 text-gray-600 rounded-xl hover:bg-gray-200 transition-all duration-300 flex items-center gap-2 text-sm font-medium"
-              onClick={() => {
-                const deletedCount = cleanupOrphanedChunks();
-                if (deletedCount > 0) {
-                  alert(`${deletedCount}개의 고아 청크 데이터가 정리되었습니다.`);
-                } else {
-                  alert('정리할 고아 데이터가 없습니다.');
-                }
-              }}
-              title="고아 청크 데이터 정리"
-            >
-              🧹 정리
-            </button>
-            
-            {/* 즉시 정리 버튼 */}
-            <button 
-              className="px-3 py-2.5 bg-red-100 text-red-600 rounded-xl hover:bg-red-200 transition-all duration-300 flex items-center gap-2 text-sm font-medium"
-              onClick={handleDeleteAll}
-              title="모든 데이터 즉시 정리"
-            >
-              🗑️ 즉시 정리
-            </button>
-            
-            <button 
-              className="px-4 py-2.5 bg-gradient-to-r from-blue-500 to-purple-600 text-white rounded-xl shadow-lg hover:shadow-xl hover:from-orange-600 hover:to-red-700 transition-all duration-300 flex items-center gap-2 font-medium"
-              onClick={openAddBookPage}
-            >
-              <Plus size={18} /> 새 원서
-            </button>
-          </div>
-        </div>
-      </div>
-      
-      {/* 메인 컨테이너 */}
-      <div className="max-w-7xl mx-auto px-6 py-8">
-        <div className="bg-white/70 backdrop-blur-sm rounded-3xl shadow-xl border border-white/20 p-8">
-          {/* 필터 */}
-          <div className="mb-8">
-            <div className="flex items-center gap-2 mb-4">
-              <span className="text-sm font-medium text-gray-700">상태별 필터:</span>
-            </div>
-            <div className="flex gap-3 flex-wrap">
-            {['전체', '읽는 중', '완료', '미시작'].map(status => (
-                <button
-                key={status}
-                onClick={() => setFilterStatus(status)}
-                  className={`px-4 py-2 rounded-full text-sm font-medium transition-all duration-300 ${
-                    filterStatus === status 
-                      ? 'bg-gradient-to-r from-blue-600 to-indigo-600 text-white shadow-lg' 
-                      : 'bg-white text-gray-600 hover:bg-gray-50 border border-gray-200 hover:border-blue-300'
-                  }`}
-              >
-                {status}
-                </button>
-            ))}
+
+          {/* 컨트롤 바 */}
+          <div className="bg-white border-b border-slate-200 px-6 py-3">
+            <div className="flex items-center justify-between">
+              {/* 검색 & 필터 */}
+              <div className="flex items-center gap-3">
+                <div className="relative">
+                  <Search size={16} className="absolute left-3 top-1/2 -translate-y-1/2 text-slate-400" />
+                  <input
+                    type="text"
+                    placeholder="원서 검색..."
+                    value={searchQuery}
+                    onChange={(e) => setSearchQuery(e.target.value)}
+                    className="pl-9 pr-4 py-2 border border-slate-200 rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent w-64"
+                  />
+                </div>
+                
+                <div className="flex items-center gap-2">
+                  {['전체', '읽는 중', '완료', '미시작'].map(status => (
+                    <button
+                      key={status}
+                      onClick={() => setFilterStatus(status)}
+                      className={`px-3 py-1.5 rounded-md text-sm font-medium transition-colors ${
+                        filterStatus === status 
+                          ? 'bg-slate-900 text-white' 
+                          : 'text-slate-600 hover:text-slate-800 hover:bg-slate-100'
+                      }`}
+                    >
+                      {status}
+                    </button>
+                  ))}
+                </div>
+              </div>
+
+              {/* 결과 수 */}
+              <div className="text-sm text-slate-500">
+                {filteredBooks.length}개의 원서
+              </div>
             </div>
           </div>
-          
-          {/* 원서 카드 리스트 */}
-          {filteredBooks.length === 0 ? (
-            <div className="text-center py-16">
-              <div className="text-6xl mb-4">📚</div>
-              <h3 className="text-xl font-semibold text-gray-700 mb-2">아직 등록된 원서가 없습니다</h3>
-              <p className="text-gray-500 mb-6">첫 번째 원서를 추가하고 학습을 시작해보세요!</p>
-              <Button 
-                onClick={openAddBookPage}
-                className="bg-gradient-to-r from-blue-600 to-indigo-600 hover:from-blue-700 hover:to-indigo-700"
-              >
-                첫 원서 추가하기
-              </Button>
-            </div>
-          ) : (
-            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-              {filteredBooks.map(book => (
-                <BookCard key={book.id} book={book} />
-              ))}
-            </div>
-          )}
+
+          {/* 메인 콘텐츠 영역 */}
+          <div className="p-6">
+            {filteredBooks.length === 0 ? (
+              <div className="text-center py-20">
+                <div className="w-16 h-16 bg-slate-100 rounded-full flex items-center justify-center mx-auto mb-4">
+                  <BookOpen size={32} className="text-slate-400" />
+                </div>
+                <h3 className="text-lg font-semibold text-slate-900 mb-2">
+                  {searchQuery ? '검색 결과가 없습니다' : filterStatus === '전체' ? '아직 등록된 원서가 없습니다' : `${filterStatus} 상태의 원서가 없습니다`}
+                </h3>
+                <p className="text-slate-600 mb-6">
+                  {searchQuery ? '다른 키워드로 검색해보세요.' : '새로운 원서를 추가하여 학습을 시작해보세요.'}
+                </p>
+                {!searchQuery && filterStatus === '전체' && (
+                  <button 
+                    onClick={openAddBookPage}
+                    className="bg-slate-900 text-white px-6 py-3 rounded-md font-medium hover:bg-slate-800 transition-colors"
+                  >
+                    첫 원서 추가하기
+                  </button>
+                )}
+              </div>
+            ) : (
+              <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+                {filteredBooks.map(book => (
+                  <BookCard key={book.id} book={book} />
+                ))}
+              </div>
+            )}
+          </div>
         </div>
       </div>
     </div>
   );
-} 
+}

--- a/src/pages/TextbookManagement/index.js
+++ b/src/pages/TextbookManagement/index.js
@@ -10,7 +10,6 @@ export default function TextbookManagement() {
   const [books, setBooks] = useState([]);
   const [searchQuery, setSearchQuery] = useState('');
   const [filterStatus, setFilterStatus] = useState('전체');
-  const [viewMode, setViewMode] = useState('grid'); // 'grid' | 'list'
 
   // 제목을 간단하게 표시하는 함수
   const getShortTitle = (title) => {

--- a/src/utils/PDFTocExtractor.js
+++ b/src/utils/PDFTocExtractor.js
@@ -1,0 +1,931 @@
+// 수정된 PDFTocExtractor.js
+import { pdfjs } from 'react-pdf';
+
+// PDF.js 워커 설정
+if (typeof window !== 'undefined' && !pdfjs.GlobalWorkerOptions.workerSrc) {
+  const pdfjsVersion = pdfjs.version || '3.11.174';
+  pdfjs.GlobalWorkerOptions.workerSrc = `//cdnjs.cloudflare.com/ajax/libs/pdf.js/${pdfjsVersion}/pdf.worker.min.js`;
+  console.log('✅ PDF.js 워커 설정 완료:', pdfjsVersion);
+}
+
+/**
+ * PDF 파일에서 목차(TOC) 추출 - 수정된 버전
+ * 이미 로드된 PDF 객체를 받아서 처리
+ */
+export const extractPDFTableOfContents = async (pdfSource) => {
+  console.log('🔍 PDF 목차 추출 시작:', typeof pdfSource);
+  
+  try {
+    let pdf = null;
+    
+    // PDF 소스가 이미 로드된 객체인지 확인
+    if (pdfSource && typeof pdfSource === 'object' && pdfSource.numPages) {
+      console.log('📄 이미 로드된 PDF 객체 사용:', pdfSource.numPages, '페이지');
+      pdf = pdfSource;
+    } else {
+      console.log('📄 새 PDF 문서 로드 시도');
+      pdf = await loadPDFDocumentWithRetry(pdfSource, 3);
+      if (!pdf) {
+        throw new Error('PDF 문서 로드 실패');
+      }
+    }
+    
+    console.log(`📄 PDF 준비 완료: ${pdf.numPages}페이지`);
+    
+    // PDF 안정화 대기
+    await ensurePDFStability(pdf);
+    
+    // 1차: PDF 북마크(outline) 추출
+    console.log('🔖 PDF 북마크 추출 시도...');
+    const bookmarkToc = await extractFromBookmarksImproved(pdf);
+    if (bookmarkToc.length > 0) {
+      console.log(`✅ 북마크에서 ${bookmarkToc.length}개 목차 추출 성공`);
+      return bookmarkToc;
+    }
+    
+    // 2차: 목차 전용 페이지 검색
+    console.log('📋 목차 페이지 검색 시도...');
+    const contentsPageToc = await extractFromContentsPageImproved(pdf);
+    if (contentsPageToc.length > 0) {
+      console.log(`✅ 목차 페이지에서 ${contentsPageToc.length}개 목차 추출 성공`);
+      return contentsPageToc;
+    }
+    
+    // 3차: 텍스트 구조 분석
+    console.log('📝 텍스트 구조 분석 시도...');
+    const textStructureToc = await extractFromTextStructure(pdf);
+    if (textStructureToc.length > 0) {
+      console.log(`✅ 텍스트 구조에서 ${textStructureToc.length}개 목차 추출 성공`);
+      return textStructureToc;
+    }
+    
+    // 4차: 기본 구조 생성
+    console.log('🔧 기본 구조 생성...');
+    const basicToc = await generateBasicStructure(pdf);
+    console.log(`✅ 기본 구조 ${basicToc.length}개 항목 생성`);
+    
+    return basicToc;
+    
+  } catch (error) {
+    console.error('❌ PDF 목차 추출 실패:', error);
+    throw error;
+  }
+};
+
+/**
+ * PDF 문서 로드 - 수정된 버전
+ */
+const loadPDFDocumentWithRetry = async (source, maxRetries = 3) => {
+  // 이미 로드된 PDF 객체인 경우 바로 반환
+  if (source && typeof source === 'object' && source.numPages) {
+    console.log('✅ 이미 로드된 PDF 객체 감지');
+    return source;
+  }
+  
+  for (let attempt = 1; attempt <= maxRetries; attempt++) {
+    try {
+      console.log(`📄 PDF 로드 시도 ${attempt}/${maxRetries}`);
+      
+      let data;
+      
+      // 소스 타입별 처리
+      if (source instanceof File) {
+        console.log('📁 File 객체 → ArrayBuffer 변환');
+        data = await source.arrayBuffer();
+      } else if (source instanceof ArrayBuffer) {
+        console.log('📦 ArrayBuffer 직접 사용');
+        data = source;
+      } else if (source instanceof Uint8Array) {
+        console.log('🔢 Uint8Array 직접 사용');
+        data = source;
+      } else if (typeof source === 'string') {
+        console.log('🔗 URL 문자열 사용');
+        data = source;
+      } else if (source && source.url) {
+        console.log('🌐 URL 객체 사용');
+        data = source.url;
+      } else {
+        throw new Error(`지원하지 않는 PDF 소스 타입: ${typeof source}`);
+      }
+      
+      // PDF 로드 옵션 최적화
+      const loadingTask = pdfjs.getDocument({
+        data: data,
+        // 기본 설정
+        useWorkerFetch: false,
+        isEvalSupported: false,
+        useSystemFonts: true,
+        verbosity: 0,
+        
+        // 스트리밍 설정
+        disableAutoFetch: false,
+        disableStream: false,
+        disableRange: false,
+        
+        // 리소스 설정
+        cMapUrl: `https://cdnjs.cloudflare.com/ajax/libs/pdf.js/${pdfjs.version || '3.11.174'}/cmaps/`,
+        cMapPacked: true,
+        standardFontDataUrl: `https://cdnjs.cloudflare.com/ajax/libs/pdf.js/${pdfjs.version || '3.11.174'}/standard_fonts/`,
+        
+        // 보안 설정
+        stopAtErrors: false,
+        maxImageSize: -1,
+        password: ''
+      });
+      
+      // 타임아웃 설정
+      const pdf = await Promise.race([
+        loadingTask.promise,
+        new Promise((_, reject) => 
+          setTimeout(() => reject(new Error('PDF 로드 타임아웃 (30초)')), 30000)
+        )
+      ]);
+      
+      console.log('✅ PDF 로드 완료:', {
+        numPages: pdf.numPages,
+        fingerprint: pdf.fingerprint?.substring(0, 8) + '...'
+      });
+      
+      return pdf;
+      
+    } catch (error) {
+      console.error(`❌ PDF 로드 시도 ${attempt} 실패:`, error.message);
+      
+      if (attempt === maxRetries) {
+        throw new Error(`PDF 로드 실패 (${maxRetries}회 시도): ${error.message}`);
+      }
+      
+      // 재시도 전 대기
+      await new Promise(resolve => setTimeout(resolve, 1000 * attempt));
+    }
+  }
+};
+
+/**
+ * PDF 안정화 대기 함수
+ */
+const ensurePDFStability = async (pdf) => {
+  try {
+    console.log('⏳ PDF 안정화 대기...');
+    
+    // 첫 페이지 접근성 테스트
+    const firstPage = await pdf.getPage(1);
+    
+    // 간단한 텍스트 컨텐츠 로드 테스트
+    try {
+      await firstPage.getTextContent();
+    } catch (textError) {
+      console.warn('⚠️ 텍스트 컨텐츠 로드 실패:', textError.message);
+    }
+    
+    // 안정화 대기
+    await new Promise(resolve => setTimeout(resolve, 500));
+    
+    console.log('✅ PDF 안정화 완료');
+  } catch (error) {
+    console.warn('⚠️ PDF 안정화 실패:', error.message);
+    // 실패해도 계속 진행
+  }
+};
+
+/**
+ * 개선된 북마크 추출 - 더 안전한 버전
+ */
+const extractFromBookmarksImproved = async (pdf) => {
+  try {
+    console.log('🔖 북마크 추출 시도...');
+    
+    let outline = null;
+    
+    // 여러 번 시도로 안정성 확보
+    for (let attempt = 1; attempt <= 3; attempt++) {
+      try {
+        console.log(`🔖 북마크 추출 시도 ${attempt}/3`);
+        
+        // getOutline 호출 전 대기
+        await new Promise(resolve => setTimeout(resolve, 200 * attempt));
+        
+        outline = await Promise.race([
+          pdf.getOutline(),
+          new Promise((_, reject) => 
+            setTimeout(() => reject(new Error('getOutline 타임아웃')), 5000)
+          )
+        ]);
+        
+        if (outline !== null) {
+          break;
+        }
+      } catch (outlineError) {
+        console.warn(`⚠️ 북마크 추출 시도 ${attempt} 실패:`, outlineError.message);
+        
+        if (attempt < 3) {
+          await new Promise(resolve => setTimeout(resolve, 500 * attempt));
+        }
+      }
+    }
+    
+    // 결과 검증
+    console.log('📚 북마크 추출 결과:', {
+      outline: !!outline,
+      isArray: Array.isArray(outline),
+      length: outline ? outline.length : 0,
+      type: typeof outline
+    });
+    
+    if (!outline || !Array.isArray(outline) || outline.length === 0) {
+      console.log('ℹ️ PDF에 유효한 북마크가 없음');
+      return [];
+    }
+    
+    // 북마크 구조 검증
+    const validBookmarks = outline.filter(bookmark => 
+      bookmark && bookmark.title && typeof bookmark.title === 'string'
+    );
+    
+    if (validBookmarks.length === 0) {
+      console.log('ℹ️ 유효한 북마크가 없음');
+      return [];
+    }
+    
+    console.log(`📋 ${validBookmarks.length}개 유효한 북마크 발견`);
+    
+    // 북마크를 목차로 변환
+    const toc = await convertBookmarksToTocSafe(pdf, validBookmarks);
+    
+    return toc;
+    
+  } catch (error) {
+    console.error('❌ 북마크 추출 실패:', error);
+    return [];
+  }
+};
+
+/**
+ * 안전한 북마크 변환 함수
+ */
+const convertBookmarksToTocSafe = async (pdf, bookmarks, level = 0) => {
+  const toc = [];
+  let idCounter = Date.now() + Math.random();
+  
+  console.log(`📖 북마크 변환 시작 - 레벨 ${level}, 개수: ${bookmarks.length}`);
+  
+  for (let i = 0; i < bookmarks.length && i < 50; i++) { // 최대 50개로 제한
+    const bookmark = bookmarks[i];
+    
+    if (!bookmark || !bookmark.title || typeof bookmark.title !== 'string') {
+      continue;
+    }
+    
+    const title = bookmark.title.trim();
+    if (!title || title.length < 2 || title.length > 200) {
+      continue;
+    }
+    
+    let pageNumber = 1;
+    
+    // 안전한 페이지 번호 추출
+    if (bookmark.dest) {
+      try {
+        pageNumber = await getPageNumberSafe(pdf, bookmark.dest);
+      } catch (destError) {
+        console.warn(`⚠️ 페이지 번호 추출 실패 for "${title}":`, destError.message);
+        
+        // 제목에서 숫자 추출 시도
+        const pageMatch = title.match(/(\d+)\s*$/);
+        if (pageMatch) {
+          const extractedPage = parseInt(pageMatch[1]);
+          if (extractedPage > 0 && extractedPage <= pdf.numPages) {
+            pageNumber = extractedPage;
+          }
+        }
+      }
+    }
+    
+    const tocItem = {
+      id: `bookmark-${idCounter++}`,
+      title: title,
+      page: pageNumber,
+      level: level,
+      children: [],
+      source: 'bookmark'
+    };
+    
+    // 하위 항목 처리 (재귀 깊이 제한)
+    if (bookmark.items && bookmark.items.length > 0 && level < 5) {
+      try {
+        const childToc = await convertBookmarksToTocSafe(pdf, bookmark.items, level + 1);
+        tocItem.children = childToc;
+      } catch (childError) {
+        console.warn(`⚠️ 하위 북마크 처리 실패 for "${title}":`, childError.message);
+      }
+    }
+    
+    toc.push(tocItem);
+  }
+  
+  console.log(`✅ 북마크 변환 완료 - 레벨 ${level}: ${toc.length}개`);
+  return toc;
+};
+
+/**
+ * 안전한 페이지 번호 추출
+ */
+const getPageNumberSafe = async (pdf, dest) => {
+  try {
+    let resolvedDest = dest;
+    
+    // Named destination 처리
+    if (typeof dest === 'string') {
+      try {
+        resolvedDest = await pdf.getDestination(dest);
+      } catch (namedDestError) {
+        console.warn(`⚠️ Named destination 해결 실패: ${namedDestError.message}`);
+        return 1;
+      }
+    }
+    
+    if (!resolvedDest || !Array.isArray(resolvedDest) || resolvedDest.length === 0) {
+      return 1;
+    }
+    
+    const pageRef = resolvedDest[0];
+    
+    // getPageIndex 시도
+    if (pageRef && typeof pageRef === 'object' && 'num' in pageRef) {
+      try {
+        const pageIndex = await pdf.getPageIndex(pageRef);
+        const pageNumber = pageIndex + 1;
+        
+        if (pageNumber >= 1 && pageNumber <= pdf.numPages) {
+          return pageNumber;
+        }
+      } catch (pageIndexError) {
+        console.warn(`⚠️ getPageIndex 실패: ${pageIndexError.message}`);
+      }
+    }
+    
+    // 직접 num 사용
+    if (pageRef && typeof pageRef.num === 'number') {
+      const estimatedPage = Math.min(Math.max(1, pageRef.num), pdf.numPages);
+      return estimatedPage;
+    }
+    
+    return 1;
+    
+  } catch (error) {
+    console.error('❌ 안전한 페이지 번호 추출 실패:', error);
+    return 1;
+  }
+};
+
+/**
+ * 목차 페이지에서 추출 - 개선된 버전
+ */
+const extractFromContentsPageImproved = async (pdf) => {
+  const toc = [];
+  let idCounter = Date.now();
+  const maxPagesToCheck = Math.min(15, pdf.numPages);
+  
+  console.log(`📋 목차 페이지 검색: ${maxPagesToCheck}페이지`);
+  
+  for (let pageNum = 1; pageNum <= maxPagesToCheck; pageNum++) {
+    try {
+      const page = await pdf.getPage(pageNum);
+      const textContent = await page.getTextContent();
+      
+      if (!textContent || !textContent.items || textContent.items.length === 0) {
+        continue;
+      }
+      
+      const pageText = textContent.items
+        .map(item => item.str || '')
+        .join(' ')
+        .toLowerCase();
+      
+      // 목차 페이지 감지 패턴
+      const tocIndicators = [
+        /목차|차례|table\s*of\s*contents|contents(?!\s+of)/i,
+        /(chapter|section)\s+\d+.*\d+/i,
+        /\.{3,}.*\d+/
+      ];
+      
+      const isContentsPage = tocIndicators.some(pattern => pattern.test(pageText));
+      
+      if (!isContentsPage) continue;
+      
+      console.log(`📋 목차 페이지 발견: ${pageNum}페이지`);
+      
+      // 텍스트 아이템 정렬 및 라인 그룹화
+      const lines = groupTextIntoLines(textContent.items);
+      
+      // 목차 항목 추출
+      const extractedCount = extractTocFromLines(lines, toc, idCounter, pdf.numPages, pageNum);
+      
+      console.log(`📋 페이지 ${pageNum}에서 ${extractedCount}개 목차 추출`);
+      
+    } catch (pageError) {
+      console.warn(`⚠️ 페이지 ${pageNum} 처리 실패:`, pageError.message);
+    }
+  }
+  
+  // 정리 및 정렬
+  const cleanedToc = toc
+    .filter(item => item.title && item.page > 0 && item.page <= pdf.numPages)
+    .sort((a, b) => a.page - b.page)
+    .slice(0, 30); // 최대 30개로 제한
+  
+  return removeDuplicates(cleanedToc);
+};
+
+/**
+ * 텍스트 아이템을 라인별로 그룹화
+ */
+const groupTextIntoLines = (textItems) => {
+  const sortedItems = textItems
+    .filter(item => item.str && item.str.trim())
+    .sort((a, b) => {
+      const yDiff = (b.transform[5] || 0) - (a.transform[5] || 0);
+      if (Math.abs(yDiff) > 5) return yDiff;
+      return (a.transform[4] || 0) - (b.transform[4] || 0);
+    });
+  
+  const lines = [];
+  let currentLine = [];
+  let currentY = null;
+  
+  for (const item of sortedItems) {
+    const y = Math.round((item.transform[5] || 0) / 5) * 5;
+    
+    if (currentY === null || Math.abs(y - currentY) <= 5) {
+      currentLine.push(item.str.trim());
+      currentY = y;
+    } else {
+      if (currentLine.length > 0) {
+        lines.push(currentLine.join(' '));
+      }
+      currentLine = [item.str.trim()];
+      currentY = y;
+    }
+  }
+  
+  if (currentLine.length > 0) {
+    lines.push(currentLine.join(' '));
+  }
+  
+  return lines;
+};
+
+/**
+ * 라인에서 목차 추출
+ */
+const extractTocFromLines = (lines, toc, idCounter, totalPages, sourcePage) => {
+  const tocPatterns = [
+    // 기본 패턴들
+    /^(chapter|ch\.?)\s+(\d+)\s*[:\-.]?\s*(.+?)\s*\.{2,}\s*(\d+)\s*$/i,
+    /^(\d+)\s*[.-]\s*(.+?)\s*\.{2,}\s*(\d+)\s*$/,
+    /^(\d+\.\d+)\s+(.+?)\s*\.{2,}\s*(\d+)\s*$/,
+    /(.+?)\s*\.{3,}\s*(\d+)\s*$/,
+    // 한국어 패턴
+    /^(제\s*\d+\s*장)\s*[:\-.]?\s*(.+?)\s*\.{2,}\s*(\d+)\s*$/,
+    // 간단한 패턴
+    /(.+?)\s+(\d+)\s*$/
+  ];
+  
+  let extractedCount = 0;
+  
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (trimmed.length < 5 || trimmed.length > 150) continue;
+    
+    // 불필요한 라인 필터링
+    if (/^(page|목차|차례|contents|table|index|\d+\s*$)/i.test(trimmed)) continue;
+    
+    for (const pattern of tocPatterns) {
+      const match = trimmed.match(pattern);
+      if (match) {
+        let title = '';
+        let pageRef = 0;
+        
+        if (match.length >= 4) {
+          title = (match[3] || match[1]).trim();
+          pageRef = parseInt(match[4] || match[2]);
+        } else if (match.length >= 3) {
+          title = match[1].trim();
+          pageRef = parseInt(match[2]);
+        }
+        
+        title = title.replace(/^[-.\s]+|\.{2,}.*$/g, '').trim();
+        
+        if (title && 
+            title.length >= 3 && 
+            title.length <= 100 &&
+            pageRef > 0 && 
+            pageRef <= totalPages &&
+            !/^\d+$/.test(title)) {
+          
+          toc.push({
+            id: `contents-${idCounter++}`,
+            title: title,
+            page: pageRef,
+            level: 0,
+            children: [],
+            source: 'contents-page',
+            sourcePage: sourcePage
+          });
+          
+          extractedCount++;
+        }
+        break;
+      }
+    }
+  }
+  
+  return extractedCount;
+};
+
+/**
+ * 텍스트 구조 분석
+ */
+const extractFromTextStructure = async (pdf) => {
+  console.log('📝 텍스트 구조 분석 시작');
+  
+  const toc = [];
+  const maxPages = Math.min(20, pdf.numPages);
+  
+  // 샘플 페이지에서 폰트 정보 수집
+  const fontAnalysis = await analyzeFontStructure(pdf, maxPages);
+  
+  if (!fontAnalysis.hasStructure) {
+    console.log('📝 텍스트 구조가 명확하지 않음');
+    return [];
+  }
+  
+  // 제목 후보 추출
+  const titleCandidates = await extractTitleCandidates(pdf, maxPages, fontAnalysis);
+  
+  // 목차 항목 생성
+  titleCandidates.forEach((candidate, index) => {
+    toc.push({
+      id: `text-${Date.now()}-${index}`,
+      title: candidate.title,
+      page: candidate.page,
+      level: candidate.level,
+      children: [],
+      source: 'text-structure',
+      confidence: candidate.confidence
+    });
+  });
+  
+  console.log(`📝 텍스트 구조 분석 완료: ${toc.length}개 항목`);
+  return toc.slice(0, 20); // 최대 20개
+};
+
+/**
+ * 폰트 구조 분석
+ */
+const analyzeFontStructure = async (pdf, maxPages) => {
+  const fontSizes = [];
+  const fontNames = new Set();
+  
+  for (let pageNum = 1; pageNum <= Math.min(5, maxPages); pageNum++) {
+    try {
+      const page = await pdf.getPage(pageNum);
+      const textContent = await page.getTextContent();
+      
+      textContent.items.forEach(item => {
+        if (item.str && item.str.trim()) {
+          const fontSize = Math.abs(item.transform[0] || 12);
+          fontSizes.push(fontSize);
+          if (item.fontName) {
+            fontNames.add(item.fontName);
+          }
+        }
+      });
+    } catch (error) {
+      console.warn(`폰트 분석 페이지 ${pageNum} 오류:`, error.message);
+    }
+  }
+  
+  if (fontSizes.length === 0) {
+    return { hasStructure: false };
+  }
+  
+  const avgSize = fontSizes.reduce((a, b) => a + b, 0) / fontSizes.length;
+  const uniqueSizes = [...new Set(fontSizes)].sort((a, b) => b - a);
+  
+  return {
+    hasStructure: uniqueSizes.length >= 3,
+    avgSize,
+    largeSize: uniqueSizes[0],
+    mediumSize: uniqueSizes[Math.floor(uniqueSizes.length * 0.3)] || avgSize,
+    fontCount: fontNames.size
+  };
+};
+
+/**
+ * 제목 후보 추출
+ */
+const extractTitleCandidates = async (pdf, maxPages, fontAnalysis) => {
+  const candidates = [];
+  
+  for (let pageNum = 1; pageNum <= maxPages; pageNum++) {
+    try {
+      const page = await pdf.getPage(pageNum);
+      const textContent = await page.getTextContent();
+      
+      textContent.items.forEach(item => {
+        if (!item.str || !item.str.trim()) return;
+        
+        const text = item.str.trim();
+        const fontSize = Math.abs(item.transform[0] || 12);
+        const fontName = item.fontName || '';
+        
+        // 제목 패턴 검사
+        let confidence = 0;
+        let level = 2;
+        
+        // 폰트 크기 기반 점수
+        if (fontSize >= fontAnalysis.largeSize * 0.95) {
+          confidence += 3;
+          level = 0;
+        } else if (fontSize >= fontAnalysis.mediumSize * 0.95) {
+          confidence += 2;
+          level = 1;
+        } else if (fontSize > fontAnalysis.avgSize * 1.2) {
+          confidence += 1;
+          level = 2;
+        }
+        
+        // 볼드체 검사
+        if (fontName.toLowerCase().includes('bold')) {
+          confidence += 1;
+        }
+        
+        // 제목 패턴 검사
+        const titlePatterns = [
+          /^(chapter|section|part)\s+\d+/i,
+          /^제\s*\d+\s*장\s*[.-]?\s*(.+?)\s*\.{2,}\s*(\d+)\s*$/,
+          /^[A-Z][A-Z\s]{5,30}$/
+        ];
+        
+        if (titlePatterns.some(pattern => pattern.test(text))) {
+          confidence += 2;
+        }
+        
+        // 유효한 제목인지 검사
+        if (confidence >= 2 && isValidTitle(text)) {
+          candidates.push({
+            title: text,
+            page: pageNum,
+            level,
+            confidence,
+            fontSize
+          });
+        }
+      });
+    } catch (error) {
+      console.warn(`제목 추출 페이지 ${pageNum} 오류:`, error.message);
+    }
+  }
+  
+  // 중복 제거 및 정렬
+  return removeDuplicates(candidates)
+    .filter(c => c.confidence >= 2)
+    .sort((a, b) => {
+      if (a.page !== b.page) return a.page - b.page;
+      return b.confidence - a.confidence;
+    })
+    .slice(0, 15);
+};
+
+/**
+ * 기본 구조 생성
+ */
+const generateBasicStructure = async (pdf) => {
+  const toc = [];
+  const totalPages = pdf.numPages;
+  const sectionCount = Math.min(6, Math.max(2, Math.floor(totalPages / 20)));
+  
+  console.log(`🔧 기본 구조 생성: ${sectionCount}개 섹션`);
+  
+  for (let i = 0; i < sectionCount; i++) {
+    const startPage = Math.floor((totalPages / sectionCount) * i) + 1;
+    const endPage = Math.min(Math.floor((totalPages / sectionCount) * (i + 1)), totalPages);
+    
+    let sectionTitle = `Section ${i + 1}`;
+    
+    // 첫 페이지에서 제목 추출 시도
+    try {
+      const page = await pdf.getPage(startPage);
+      const textContent = await page.getTextContent();
+      
+      const topItems = textContent.items
+        .filter(item => item.str && item.str.trim() && (item.transform[5] || 0) > 700)
+        .sort((a, b) => (b.transform[5] || 0) - (a.transform[5] || 0))
+        .slice(0, 2);
+      
+      const topText = topItems.map(item => item.str.trim()).join(' ');
+      
+      if (topText && topText.length > 3 && topText.length < 60) {
+        const cleanTitle = topText.replace(/[^\w\s가-힣]/g, ' ').trim();
+        if (cleanTitle && isValidTitle(cleanTitle)) {
+          sectionTitle = cleanTitle;
+        }
+      }
+    } catch (pageError) {
+      console.warn(`구간 ${i + 1} 제목 추출 실패:`, pageError.message);
+    }
+    
+    toc.push({
+      id: `basic-${Date.now()}-${i}`,
+      title: sectionTitle,
+      page: startPage,
+      level: 0,
+      children: [],
+      source: 'basic-structure',
+      pageRange: `${startPage}-${endPage}`
+    });
+  }
+  
+  return toc;
+};
+
+/**
+ * 유효한 제목인지 검증
+ */
+const isValidTitle = (title) => {
+  if (!title || typeof title !== 'string') return false;
+  
+  const trimmed = title.trim();
+  if (trimmed.length < 2 || trimmed.length > 150) return false;
+  
+  // 숫자만 있는 경우 제외
+  if (/^\d+\.?\s*$/.test(trimmed)) return false;
+  
+  // 무효한 패턴들
+  const invalidPatterns = [
+    /^page\s*\d*$/i,
+    /^pdf$/i,
+    /^document$/i,
+    /^copyright/i,
+    /^www\./i,
+    /^http/i,
+    /^email/i,
+    /^\.{3,}$/,
+    /^_{3,}$/,
+    /^-{3,}$/,
+    /^blank$/i,
+    /intentionally/i,
+    /^\s*$/
+  ];
+  
+  if (invalidPatterns.some(pattern => pattern.test(trimmed))) {
+    return false;
+  }
+  
+  // 의미있는 문자 포함 여부
+  const hasValidChars = /[a-zA-Z가-힣\u3040-\u309F\u30A0-\u30FF\u4E00-\u9FAF]{2,}/.test(trimmed);
+  
+  return hasValidChars;
+};
+
+/**
+ * 중복 제거 함수
+ */
+const removeDuplicates = (items, key = 'title') => {
+  const seen = new Map();
+  const unique = [];
+  
+  items.forEach(item => {
+    if (!item || !item[key]) return;
+    
+    const keyValue = item[key].toLowerCase()
+      .replace(/\s+/g, ' ')
+      .replace(/[^\w\s가-힣]/g, '')
+      .trim();
+    
+    if (!keyValue) return;
+    
+    const existing = seen.get(keyValue);
+    if (!existing || (item.confidence && item.confidence > (existing.confidence || 0))) {
+      if (existing) {
+        const existingIndex = unique.findIndex(u => u === existing);
+        if (existingIndex >= 0) unique.splice(existingIndex, 1);
+      }
+      seen.set(keyValue, item);
+      unique.push(item);
+    }
+  });
+  
+  return unique;
+};
+
+/**
+ * PDF 메타데이터 추출
+ */
+export const extractPDFMetadata = async (pdf) => {
+  try {
+    console.log('📋 PDF 메타데이터 추출');
+    
+    const metadata = await pdf.getMetadata();
+    const info = {
+      title: '',
+      author: '',
+      subject: '',
+      producer: '',
+      creator: '',
+      creationDate: null,
+      modificationDate: null
+    };
+    
+    if (metadata?.info) {
+      const meta = metadata.info;
+      info.title = meta.Title || '';
+      info.author = meta.Author || '';
+      info.subject = meta.Subject || '';
+      info.producer = meta.Producer || '';
+      info.creator = meta.Creator || '';
+      info.creationDate = meta.CreationDate || null;
+      info.modificationDate = meta.ModDate || null;
+    }
+    
+    return info;
+  } catch (error) {
+    console.error('❌ 메타데이터 추출 실패:', error);
+    return {
+      title: '', author: '', subject: '', producer: '', 
+      creator: '', creationDate: null, modificationDate: null
+    };
+  }
+};
+
+/**
+ * 파일에서 직접 목차 추출
+ */
+export const extractFromPDFFile = async (file) => {
+  try {
+    console.log('📁 파일에서 목차 추출:', file.name);
+    
+    if (!file || file.type !== 'application/pdf') {
+      throw new Error('유효한 PDF 파일이 아닙니다');
+    }
+    
+    const pdf = await loadPDFDocumentWithRetry(file);
+    const toc = await extractPDFTableOfContents(pdf);
+    const metadata = await extractPDFMetadata(pdf);
+    
+    return {
+      toc,
+      metadata,
+      numPages: pdf.numPages
+    };
+  } catch (error) {
+    console.error('❌ 파일 목차 추출 실패:', error);
+    throw error;
+  }
+};
+
+/**
+ * 디버깅용 PDF 구조 분석
+ */
+export const debugPDFStructure = async (pdf) => {
+  try {
+    console.log('🔍 PDF 구조 디버깅');
+    console.log(`📄 총 페이지: ${pdf.numPages}`);
+    
+    // 북마크 체크
+    try {
+      const outline = await pdf.getOutline();
+      console.log('🔖 북마크 상태:', {
+        exists: !!outline,
+        count: outline ? outline.length : 0
+      });
+    } catch (outlineError) {
+      console.log('❌ 북마크 확인 실패:', outlineError.message);
+    }
+    
+    // 첫 페이지 텍스트 샘플
+    try {
+      const page = await pdf.getPage(1);
+      const textContent = await page.getTextContent();
+      console.log('📝 첫 페이지 텍스트:', {
+        itemCount: textContent.items.length,
+        sample: textContent.items.slice(0, 3).map(item => item.str).join(' ')
+      });
+    } catch (textError) {
+      console.log('❌ 텍스트 확인 실패:', textError.message);
+    }
+    
+  } catch (error) {
+    console.error('❌ 구조 디버깅 실패:', error);
+  }
+};
+
+const PDFTocExtractor = {
+  extractPDFTableOfContents,
+  extractPDFMetadata,
+  extractFromPDFFile,
+  debugPDFStructure
+};
+
+export default PDFTocExtractor;


### PR DESCRIPTION
1. 사이드 바 및 해더 수정 [V]
2. 노트 메모 드래그 부분 인식 해결 [V]
3. 학습 모드에서 해더를 하나만 가져가고, 지금 현재 화면에 스크롤이 두개가 생겨서(전체 화면과 노트 표시 container) 하나만 가져가게  [V]
4. 챕터 불러오기 [V]
5. 주간 학습 목표 (챕터 계획에서 사용자가 추가로 잡는것(이거는 원서 상세에서)) [v]
6. 노트 부분은 챕터와 페이지가 뜨게 [V]
7. 학습 시간은 사용자가 학습 모드 화면에서 머문 시간이 측정 되게. [V]
8. 모든 화면 레이아웃 통일 및 디자인의 퀄리티 올리기 [V]

<img width="1913" height="938" alt="image" src="https://github.com/user-attachments/assets/4bb27ad2-87cb-42e5-b726-70aeb4c8e7e2" />
<img width="1893" height="938" alt="image" src="https://github.com/user-attachments/assets/1857d268-9ee7-4b14-9c1a-c968c4efcd09" />
<img width="1910" height="935" alt="image" src="https://github.com/user-attachments/assets/745b11ad-6e4d-43a3-9d6f-e3fd8672c1f9" />
<img width="1904" height="926" alt="image" src="https://github.com/user-attachments/assets/0b23b7ee-0467-458c-8612-5ea541466c19" />
<img width="1912" height="933" alt="image" src="https://github.com/user-attachments/assets/ec31dc42-6dbe-4344-afe0-7895594d4ed2" />
<img width="1893" height="931" alt="image" src="https://github.com/user-attachments/assets/970df439-d5ae-45ec-aff8-7136df16a607" />
<img width="1893" height="939" alt="image" src="https://github.com/user-attachments/assets/5f2e9e82-8187-470b-82d3-d552befa122a" />
<img width="1893" height="933" alt="image" src="https://github.com/user-attachments/assets/dfb22d36-c3fe-4b82-83e6-da11bc527758" />
